### PR TITLE
Icon Link with text value

### DIFF
--- a/packages/component-library/src/components/Link/Link.stories.tsx
+++ b/packages/component-library/src/components/Link/Link.stories.tsx
@@ -18,7 +18,7 @@ export default {
       name: 'Variant',
       control: {
         type: 'select',
-        options: ['link', 'button-contained', 'button-outlined', 'button-text']
+        options: ['link', 'button-contained', 'button-outlined', 'button-text', '']
       },
       table: {
         defaultValue: { summary: 'link' }

--- a/packages/component-library/src/components/Link/Link.tsx
+++ b/packages/component-library/src/components/Link/Link.tsx
@@ -107,7 +107,12 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
    * - Classes reference FontAwesome stylesheet linked in .storybook/preview
    * - Include that css file in head of any given project to render
    */
-  if (!text && icon) {
+  // TODOs:
+  // - 1. Create variant `icon only`?
+  // --> ((variant === 'icon-only' || !variant) && icon)
+  // - 2. Create Link with Icon version
+  // --> https://next.material-ui.com/components/buttons/#buttons-with-icons-and-label
+  if (!variant && icon) {
     if (isExternal) {
       return (
         <a


### PR DESCRIPTION
https://lastrev.atlassian.net/browse/STRONG-95

🗒️ Fixes the element so that if a value for `text` exists, it will still show the icon as intended.

🔗 [Preview URL](https://deploy-preview-73--lr-components.netlify.app/?path=/story/1-primitives-mui-link--default&args=variant:)

---

<img width="388" alt="icon" src="https://user-images.githubusercontent.com/937917/129686674-5eea9879-673d-48cd-b902-6f3dfaaa79a8.png">
