### PR TITLE
Icon Link

### DIFF
--- a/packages/component-library/src/components/Link/Link.mock.tsx
+++ b/packages/component-library/src/components/Link/Link.mock.tsx
@@ -4,5 +4,5 @@ export default {
   variant: 'button-contained',
   href: lorem.word(),
   text: lorem.words(2),
-  icon: 'Instagram'
+  icon: 'instagram'
 };

--- a/packages/component-library/src/components/Link/Link.stories.tsx
+++ b/packages/component-library/src/components/Link/Link.stories.tsx
@@ -30,7 +30,7 @@ export default {
       name: 'Icon',
       control: {
         type: 'select',
-        options: ['Instagram', 'Facebook', 'Twitter', 'YouTube']
+        options: ['instagram', 'facebook', 'twitter', 'youtube', 'chevron-right', 'caret-right']
       },
       table: {
         defaultValue: { summary: 'Instagram' }

--- a/packages/component-library/src/components/Link/Link.tsx
+++ b/packages/component-library/src/components/Link/Link.tsx
@@ -107,12 +107,14 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
    * - Classes reference FontAwesome stylesheet linked in .storybook/preview
    * - Include that css file in head of any given project to render
    */
-  // TODOs:
-  // - 1. Create variant `icon only`?
-  // --> ((variant === 'icon-only' || !variant) && icon)
-  // - 2. Create Link with Icon version
+  // NOTES:
+  // - 1. ** Custom for Strong365 using FontAwesome **
+  // -->  ** Is it possible to extend in that repo? **
+  // - 2. Better to use SVG
+  // --> https://material-ui.com/components/icons/#font-vs-svg-which-approach-to-use
+  // - 3. TODOs: Create Link with Icon version
   // --> https://next.material-ui.com/components/buttons/#buttons-with-icons-and-label
-  if (!variant && icon) {
+  if (icon && !text) {
     if (isExternal) {
       return (
         <a
@@ -122,8 +124,8 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
           target="_blank"
           rel="noopener noreferrer"
           {...extra}>
-          <IconButton aria-label={text}>
-            <Icon className={`fa${brandIcons.includes(icon.toLowerCase()) ? 'b' : ''} fa-${icon.toLowerCase()}`} />
+          <IconButton aria-label={icon}>
+            <Icon className={`fa${brandIcons.includes(icon.toLowerCase()) ? 'b' : 's'} fa-${icon.toLowerCase()}`} />
           </IconButton>
         </a>
       );
@@ -132,7 +134,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
       return (
         <NextLink href={href} as={linkAs}>
           <IconButton aria-label={icon} type={other.type} {...extra}>
-            <Icon className={`fa${brandIcons.includes(icon.toLowerCase()) ? 'b' : ''} fa-${icon.toLowerCase()}`} />
+            <Icon className={`fa${brandIcons.includes(icon.toLowerCase()) ? 'b' : 's'} fa-${icon.toLowerCase()}`} />
           </IconButton>
         </NextLink>
       );


### PR DESCRIPTION
https://lastrev.atlassian.net/browse/STRONG-95

⚠️ NOTE: Solution is custom for Strong365, using FontAwesome, and ideally would be extended from the LRCL component in that repo.

---

References `icon` field in CMS

Screenshot:

<img width="167" alt="icon" src="https://user-images.githubusercontent.com/937917/130026318-92b57d0c-ecd0-4628-8dbb-a0330bdc2d50.png">
