### PR TITLE
Link with icon

### DIFF
--- a/packages/component-library/src/components/Link/Link.mock.tsx
+++ b/packages/component-library/src/components/Link/Link.mock.tsx
@@ -5,6 +5,6 @@ export default {
   variant: 'button-contained',
   href: lorem.word(),
   text: lorem.words(2),
-  icon: 'instagram',
+  icon: 'chevron-right',
   iconPosition: 'Right'
 };

--- a/packages/component-library/src/components/Link/Link.stories.tsx
+++ b/packages/component-library/src/components/Link/Link.stories.tsx
@@ -30,7 +30,7 @@ export default {
       name: 'Icon',
       control: {
         type: 'select',
-        options: ['instagram', 'facebook', 'twitter', 'youtube', 'chevron-right', 'caret-right']
+        options: ['instagram', 'facebook', 'twitter', 'youtube', 'chevron-right', 'caret-right', '']
       },
       table: {
         defaultValue: { summary: 'Instagram' }

--- a/packages/component-library/src/components/Link/Link.tsx
+++ b/packages/component-library/src/components/Link/Link.tsx
@@ -68,6 +68,7 @@ export type LinkProps = {
   variant?: 'button-contained' | 'button-outlined' | 'button-text' | 'text' | any;
   icon?: string;
   iconPosition?: string;
+  children?: any;
   onClick?: any;
   type?: string;
   sidekickLookup?: any;
@@ -80,6 +81,21 @@ const getIcon = (icon: string) => {
   const brandIcons = ['google', 'twitter', 'facebook', 'github', 'linkedin', 'pinterest', 'instagram', 'youtube'];
   return (
     <Icon className={`fa${brandIcons.includes(icon.toLowerCase()) ? 'b' : 's'} fa-${icon.toLowerCase()}`} />
+  )
+};
+
+const getButtonContent = (text: string | undefined, children: any, iconPosition: string | undefined, icon: any) => {
+  return (
+    <ButtonWrap sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
+      <span>
+        {text || children}
+      </span>
+      {icon && (
+        <Box sx={{ margin: iconPosition === 'Left' ? '0 10px 0 0' : '0 0 0 10px' }}>
+          {icon && getIcon(icon)}
+        </Box>
+      )}
+    </ButtonWrap>
   )
 };
 
@@ -164,32 +180,14 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
     if (noLinkStyle) {
       return (
         <a className={className} href={href as string} ref={ref as any} {...extra}>
-          <ContentWrapper sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
-            <span>
-              {text || children}
-            </span>
-            {icon && (
-              <Box sx={{ margin: iconPosition === 'Left' ? '0 10px 0 0' : '0 0 0 10px' }}>
-                {icon && getIcon(icon)}
-              </Box>
-            )}
-          </ContentWrapper>
+          {getButtonContent(text, children, iconPosition, icon)}
         </a>
       );
     }
 
     return (
       <MuiLink className={className} href={href as string} ref={ref} {...extra}>
-        <ContentWrapper sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
-          <span>
-            {text || children}
-          </span>
-          {icon && (
-            <Box sx={{ margin: iconPosition === 'Left' ? '0 10px 0 0' : '0 0 0 10px' }}>
-              {icon && getIcon(icon)}
-            </Box>
-          )}
-        </ContentWrapper>
+        {getButtonContent(text, children, iconPosition, icon)}
       </MuiLink>
     );
   }
@@ -197,7 +195,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
   if (noLinkStyle) {
     return (
       <NextLinkComposed className={className} ref={ref as any} to={href} {...extra}>
-        <ContentWrapper sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
+        <ButtonWrap sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
           <span>
             {children || text}
           </span>
@@ -206,7 +204,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
               {icon && getIcon(icon)}
             </Box>
           )}
-        </ContentWrapper>
+        </ButtonWrap>
       </NextLinkComposed>
     );
   }
@@ -216,59 +214,37 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
     if (href !== '#') {
       return (
         <NextLink href={href} as={linkAs}>
-          <Button variant={buttonVariant} type={other.type} {...extra}>
-            <ContentWrapper sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
-              <span>
-                {text || children}
-              </span>
-              {icon && (
-                <Box sx={{ margin: iconPosition === 'Left' ? '0 10px 0 0' : '0 0 0 10px' }}>
-                  {icon && getIcon(icon)}
-                </Box>
-              )}
-            </ContentWrapper>
+          <Button variant={buttonVariant} type={other.type} {...extra}
+            startIcon={icon && iconPosition === 'Left' && getIcon(icon)}
+            endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}
+          >
+            {text || children}
           </Button>
         </NextLink>
       );
     }
     return (
-      <Button variant={buttonVariant} onClick={other.onClick} type={other.type} {...extra}>
-        <ContentWrapper sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
-          <span>
-            {text || children}
-          </span>
-          {icon && (
-            <Box sx={{ margin: iconPosition === 'Left' ? '0 10px 0 0' : '0 0 0 10px' }}>
-              {icon && getIcon(icon)}
-            </Box>
-          )}
-        </ContentWrapper>
+      <Button variant={buttonVariant} onClick={other.onClick} type={other.type} {...extra}
+        startIcon={icon && iconPosition === 'Left' && getIcon(icon)}
+        endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}
+      >
+        {text || children}
       </Button>
     );
   }
   return (
     <MuiLink component={NextLinkComposed} linkAs={linkAs} className={className} ref={ref} to={href} {...extra}>
-      <ContentWrapper sx={{ flexDirection: iconPosition === 'Left' ? 'row-reverse' : undefined }}>
-        <span>
-          {text || children}
-        </span>
-        {icon && (
-          <Box sx={{ margin: iconPosition === 'Left' ? '0 10px 0 0' : '0 0 0 10px' }}>
-            {icon && getIcon(icon)}
-          </Box>
-        )}
-      </ContentWrapper>
+      {getButtonContent(text, children, iconPosition, icon)}
     </MuiLink>
   );
 });
 
-const ContentWrapper = styled(Box, {
+const ButtonWrap = styled(Box, {
   name: 'Box',
   slot: 'Content',
 })<{}>(() => ({
   display: 'inline-flex',
   alignItems: 'center',
-  // height: 24,
 }));
 
 export default Link;

--- a/packages/component-library/src/theme/mock.theme.ts
+++ b/packages/component-library/src/theme/mock.theme.ts
@@ -368,7 +368,13 @@ const theme = createAppTheme(
         styleOverrides: {
           root: {
             fontWeight: 'bold',
-            padding: baseTheme.spacing(2, 3)
+            padding: baseTheme.spacing(2, 3),
+            '& .MuiButton-startIcon': {
+              display: 'inline',
+            },
+            '& .MuiButton-endIcon': {
+              display: 'inline',
+            }
           },
           outlinedPrimary: {
             color: baseTheme.palette.text.primary,


### PR DESCRIPTION
https://lastrev.atlassian.net/browse/STRONG-109

---

Adds an icon in addition to text for `Link` component

[Preview URL](https://deploy-preview-79--lr-components.netlify.app/?path=/story/1-primitives-mui-link--default&args=icon:caret-right)

---

<img width="326" alt="icon" src="https://user-images.githubusercontent.com/937917/130463666-91c13d7a-cae8-49a5-965c-9f499a78ae72.png">
