### PR TITLE
Profile card variants

### DIFF
--- a/packages/component-library/src/components/Card/Card.mock.ts
+++ b/packages/component-library/src/components/Card/Card.mock.ts
@@ -5,14 +5,13 @@ import { paragraphMock } from '../Text/Text.mock';
 
 export default {
   __typename: 'Card',
-  // variant: 'standard-blog',
-  variant: 'profile',
+  variant: 'profile-row',
   media: {
     __typename: 'Media',
     file: {
       url: 'https://i.picsum.photos/id/237/690/388.jpg?hmac=Zuv-CcXEfzBDJlr7G8wx67jMiWLssNTUppetu6ohvLc'
     },
-    alt: 'Contemplative Lizard'
+    alt: capitalize(lorem.words(2))
   },
   title: capitalize(lorem.word()),
   subtitle: capitalize(lorem.words(3)),

--- a/packages/component-library/src/components/Card/Card.stories.tsx
+++ b/packages/component-library/src/components/Card/Card.stories.tsx
@@ -24,8 +24,9 @@ export default {
           'media',
           'media-hover',
           'media-and-text',
-          'profile',
-          'profile-large',
+          'profile-column',
+          'profile-row',
+          'profile-image',
           'square',
           'standard-blog'
         ]

--- a/packages/component-library/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/component-library/src/components/Carousel/Carousel.stories.tsx
@@ -18,7 +18,7 @@ export default {
       name: 'Variant'
       // control: {
       //   type: 'select',
-      //   options: ['standard', 'standard-round', 'media', 'profile', 'profile-large', 'square']
+      //   options: ['standard', 'standard-round', 'media', 'profile-column', 'profile-row', 'profile-image', 'square']
       // },
       // table: {
       //   defaultValue: { summary: 'standard' }

--- a/packages/component-library/src/components/Collection/Collection.stories.tsx
+++ b/packages/component-library/src/components/Collection/Collection.stories.tsx
@@ -32,7 +32,7 @@ export default {
       name: 'Items Variant',
       control: {
         type: 'select',
-        options: ['standard', 'standard-round', 'media', 'profile', 'profile-large', 'square', 'standard-blog']
+        options: ['standard', 'standard-round', 'media', 'profile-column', 'profile-row', 'profile-image', 'square', 'standard-blog']
       },
       table: {
         defaultValue: { summary: 'standard' }

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.stories.tsx
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.stories.tsx
@@ -32,8 +32,9 @@ export default {
           'media',
           'media-hover',
           'media-and-text',
-          'profile',
-          'profile-large',
+          'profile-column',
+          'profile-row',
+          'profile-image',
           'square'
         ]
       },

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.stories.tsx
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.stories.tsx
@@ -26,7 +26,7 @@ export default {
       name: 'Items Variant',
       control: {
         type: 'select',
-        options: ['standard', 'standard-round', 'media', 'media-and-text', 'profile', 'profile-large', 'square']
+        options: ['standard', 'standard-round', 'media', 'media-and-text', 'profile-column', 'profile-row', 'profile-image', 'square']
       },
       table: {
         defaultValue: { summary: 'media-and-text' }

--- a/packages/component-library/src/components/Media/Media.mock.ts
+++ b/packages/component-library/src/components/Media/Media.mock.ts
@@ -29,7 +29,7 @@ export default {
     },
     {
       ...cardMock,
-      variant: 'profile',
+      variant: 'profile-column',
       title: name.findName(),
       subtitle: name.jobTitle(),
       body: lorem.sentence(),
@@ -38,7 +38,16 @@ export default {
     },
     {
       ...cardMock,
-      variant: 'profile-large',
+      variant: 'profile-row',
+      title: name.findName(),
+      subtitle: name.jobTitle(),
+      body: lorem.sentence(),
+      ctas: null,
+      theme: [mockTheme]
+    },
+    {
+      ...cardMock,
+      variant: 'profile-image',
       title: null,
       subtitle: null,
       body: null,

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.stories.tsx
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.stories.tsx
@@ -31,7 +31,7 @@ export default {
       name: 'Items Variant',
       control: {
         type: 'select',
-        options: ['standard', 'standard-round', 'media', 'profile', 'profile-large', 'square']
+        options: ['standard', 'standard-round', 'media', 'profile-column', 'profile-row', 'profile-image', 'square']
       },
       table: {
         defaultValue: { summary: 'standard' }

--- a/packages/component-library/src/theme/createCardVariants.ts
+++ b/packages/component-library/src/theme/createCardVariants.ts
@@ -113,9 +113,43 @@ export const mediaAndTextCardVariant = (theme: Theme) => ({
   }
 });
 
-export const profileCardVariant = (theme: Theme) => ({
+export const profileColumnCardVariant = (theme: Theme) => ({
   props: {
-    variant: 'profile'
+    variant: 'profile-column'
+  },
+  style: {
+    'display': 'flex',
+    'justifyContent': 'center',
+    'flexDirection': 'column',
+    'minWidth': 320,
+    'padding': theme.spacing(0, 3, 6),
+    maxWidth: '100%',
+    '& img': {
+      width: 280,
+      height: 280,
+      marginTop: theme.spacing(6),
+      borderRadius: '50%',
+      border: `2px solid ${theme.palette.primary.main}`,
+      objectFit: 'cover'
+    },
+    '& .MuiCardActions-root': {
+      display: 'flex'
+    },
+    '& .MuiCardContent-root': {
+      'padding': theme.spacing(6, 4, 0),
+      '&:last-child': {
+        paddingBottom: 0
+      },
+    },
+    '& .MuiTypography-h3': {
+      color: 'black'
+    }
+  }
+});
+
+export const profileRowCardVariant = (theme: Theme) => ({
+  props: {
+    variant: 'profile-row'
   },
   style: {
     'display': 'flex',
@@ -157,23 +191,22 @@ export const profileCardVariant = (theme: Theme) => ({
   }
 });
 
-export const profileLargeCardVariant = (theme: Theme) => ({
+export const profileImageCardVariant = (theme: Theme) => ({
   props: {
-    variant: 'profile-large'
+    variant: 'profile-image'
   },
   style: {
     'justifyContent': 'center',
     'width': '100%',
     'minWidth': 200,
-    'height': 300,
     'padding': 20,
     '& img': {
       width: '100%',
-      maxWidth: 260,
       height: '100%',
       borderRadius: '50%',
       border: `2px solid ${theme.palette.primary.main}`,
-      objectFit: 'cover'
+      objectFit: 'cover',
+      aspectRatio: '1'
     },
 
     '& .MuiCardContent-root': {
@@ -387,15 +420,16 @@ export const standardBlogCardVariant = (theme: Theme) => ({
 });
 
 const variants = [
-  mediaCardVariant,
-  mediaAndTextCardVariant,
-  profileCardVariant,
-  profileLargeCardVariant,
-  squareCardVariant,
   standardCardVariant,
   standardRoundedCardVariant,
+  standardBlogCardVariant,
+  mediaCardVariant,
   mediaHoverCardVariant,
-  standardBlogCardVariant
+  mediaAndTextCardVariant,
+  profileColumnCardVariant,
+  profileRowCardVariant,
+  profileImageCardVariant,
+  squareCardVariant
 ];
 
 const createCardVariants = (theme: Theme) => {


### PR DESCRIPTION
https://lastrev.atlassian.net/browse/STRONG-120

Card profile create two separate variants: vertical, horizontal orientation

🔗 [Preview URL](https://deploy-preview-95--lr-components.netlify.app/?path=/story/1-primitives-mui-card--default)

**Notes:**
* Changed variant names to: `profile-column`, `profile-row` and `profile-image`
* Updated field names in [Contentful](https://app.contentful.com/spaces/m1b67l45sk9z/content_types/card/fields)
* Changed content items to match new field names ([example row](https://app.contentful.com/spaces/m1b67l45sk9z/environments/master/entries/PLxAE2iKQdLMQWCaejj6R), [example column](https://app.contentful.com/spaces/m1b67l45sk9z/entries/2LsGqqU5bDaeUYZVmXpZ1r))
* Goes with [Strong365 PR 50](https://github.com/last-rev-llc/strong365-web/pull/50) which updates the references to old variant names in Strong365 repo

---

<img width="587" alt="card" src="https://user-images.githubusercontent.com/937917/131627841-4a1fca24-6600-442f-83f4-612249601393.png">
