### PR TITLE
Hero centered image size

### DIFF
--- a/packages/component-library/src/components/Hero/Hero.mock.ts
+++ b/packages/component-library/src/components/Hero/Hero.mock.ts
@@ -4,13 +4,13 @@ import mockLink from '../Link/Link.mock';
 import mockTheme from '../../theme/mock.theme';
 
 export default {
-  variant: 'default',
+  variant: 'centered',
   title: capitalize(lorem.words(3)),
   subtitle: lorem.sentence(),
   image: {
     __typename: 'Media',
     file: {
-      url: 'https://images.ctfassets.net/m1b67l45sk9z/4jtNAOSr68TdEVcsuuEPoh/1443dafc62dc2d264fbca495f0f20c09/Exampleimage.png'
+      url: 'https://images.ctfassets.net/m1b67l45sk9z/4Oj0gAEf0wFiPfg0R3QHqG/b1f835f3e380670cd6484e486c9816b1/it-gets-better.png?h=800'
     },
     alt: 'Not Alone'
   },
@@ -68,5 +68,7 @@ export default {
   actions: [{ ...mockLink, text: 'Hero CTA' }],
   background: null,
   backgroundColor: 'white',
+  contentHeight: 'xl',
+  contentWidth: 'xl',
   theme: [mockTheme]
 };

--- a/packages/component-library/src/components/Hero/Hero.stories.tsx
+++ b/packages/component-library/src/components/Hero/Hero.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Box from '@material-ui/core/Box';
 import Hero from './Hero';
 import heroMock from './Hero.mock';
 
@@ -7,9 +6,7 @@ export default {
   title: '1. Primitives / MUI / Hero',
   component: Hero,
   decorators: [
-    (storyFn: () => boolean | React.ReactChild | React.ReactFragment | React.ReactPortal) => (
-      <Box m={5}>{storyFn()}</Box>
-    )
+    (storyFn: () => boolean | React.ReactChild | React.ReactFragment | React.ReactPortal) => storyFn()
   ],
   argTypes: {
     variant: {
@@ -35,6 +32,26 @@ export default {
       },
       table: {
         defaultValue: { summary: 'none' }
+      }
+    },
+    contentHeight: {
+      name: 'Content Height',
+      control: {
+        type: 'inline-radio',
+        options: ['sm', 'md', 'lg', 'xl']
+      },
+      table: {
+        defaultValue: { summary: 'md' }
+      }
+    },
+    contentWidth: {
+      name: 'Content Width',
+      control: {
+        type: 'inline-radio',
+        options: ['xs', 'sm', 'md', 'lg', 'xl']
+      },
+      table: {
+        defaultValue: { summary: 'xl' }
       }
     },
     actions: { name: 'Actions' },

--- a/packages/component-library/src/components/Hero/Hero.tsx
+++ b/packages/component-library/src/components/Hero/Hero.tsx
@@ -25,7 +25,7 @@ export interface HeroProps {
   background?: MediaProps;
   backgroundColor?: string;
   contentWidth?: false | Breakpoint | undefined;
-  contentHeight?: 'sm' | 'md' | 'lg';
+  contentHeight?: 'sm' | 'md' | 'lg' | 'xl';
   variant?: any;
   theme: any;
   styles?: {
@@ -42,7 +42,7 @@ export const Hero = ({
   background,
   backgroundColor,
   contentWidth,
-  contentHeight = 'md',
+  contentHeight = 'lg',
   title,
   subtitle,
   body,
@@ -63,25 +63,26 @@ HeroProps) => {
           position: background ? 'relative' : undefined,
           overflow: background ? 'hidden' : undefined
         }}>
+        {background ? (
+          <Box
+            sx={{
+              position: 'absolute',
+              zIndex: -1,
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%'
+            }}>
+            <Media
+              {...background}
+              {...sidekick(sidekickLookup?.background)}
+              sx={{ objectFit: 'cover', width: '100%', height: '100%' }}
+            />
+          </Box>
+        ) : null}
         <ContentContainer maxWidth={contentWidth}>
-          <Grid container spacing={5}>
-            {background ? (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  zIndex: -1,
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: '100%'
-                }}>
-                <Media
-                  {...background}
-                  {...sidekick(sidekickLookup?.background)}
-                  sx={{ objectFit: 'cover', width: '100%', height: '100%' }}
-                />
-              </Box>
-            ) : null}
+          <Grid container rowSpacing={5}
+            columnSpacing={variant === 'centered' ? 0 : 5}>
             {title || subtitle || body || actions ? (
               <Grid container direction="column" spacing={2} xs={12}>
                 <Grid item>
@@ -212,7 +213,21 @@ const ContentContainer = styled(Container, {
   })
 })<{ variant?: string }>(({ theme }) => ({
   padding: theme.spacing(5),
-  height: '100%'
+  height: '100%',
+  [theme.breakpoints.down('lg')]: {
+    '& > div': {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)'
+    },
+  },
+  [theme.breakpoints.up('md')]: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignContent: 'center'
+  }
+
 }));
 
 export default Hero;

--- a/packages/component-library/src/theme/createHeroVariants.ts
+++ b/packages/component-library/src/theme/createHeroVariants.ts
@@ -58,10 +58,19 @@ export const centeredVariant = (theme: Theme) => ({
       padding: theme.spacing(4, 0)
     },
     '& > .MuiContainer-root > .MuiGrid-container': {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      flexDirection: 'column',
+      justifyContent: 'center',
       maxWidth: theme.breakpoints.values.lg,
       margin: '0 auto',
-      justifyContent: 'center',
-      flexDirection: 'column'
+      transform: 'translate(-50%, -50%)',
+      [theme.breakpoints.down('sm')]: {
+        '& div:nth-child(2)': {
+          maxWidth: '80%'
+        }
+      }
     },
     '& .MuiGrid-root': {
       textAlign: 'center'


### PR DESCRIPTION
#### Description

Section featured image on centered variant appears too small

**TODO**:
* Add styles to Strong365 repo ([PR #56](https://github.com/last-rev-llc/strong365-web/pull/56))

---

##### 🔹 Jira Ticket
https://lastrev.atlassian.net/browse/STRONG-159

##### 🔗 Preview URLs:
- [Storybook](https://deploy-preview-104--lr-components.netlify.app/?path=/story/1-primitives-mui-hero--background-image)
- [CMS](https://app.contentful.com/spaces/m1b67l45sk9z/entries/3kmcY4bDqAkqQel4gtPXDR?previousEntries=4bjCGmM50K7qT7anItIuSi)

##### 🔬 How to test
* View `Hero` at different breakpoints
* Image on `centered` variant should be a bit larger

##### 📸  Screenshot
<img width="600" alt="hero" src="https://user-images.githubusercontent.com/937917/132294805-afc6a16c-b08e-43be-af38-770f956f34ed.png">

---
 
##### Changes include
- [x] Bug fix (_non-breaking change that solves an issue_)

 