### PR TITLE
Cards equal height

### DIFF
--- a/packages/component-library/src/components/Card/Card.mock.ts
+++ b/packages/component-library/src/components/Card/Card.mock.ts
@@ -13,7 +13,7 @@ export default {
     },
     alt: capitalize(lorem.words(2))
   },
-  title: capitalize(lorem.word()),
+  title: capitalize(lorem.words(2)),
   subtitle: capitalize(lorem.words(3)),
   body: paragraphMock,
   actions: [{ ...mockLink }]

--- a/packages/component-library/src/components/Collection/Collection.mock.ts
+++ b/packages/component-library/src/components/Collection/Collection.mock.ts
@@ -1,10 +1,11 @@
+import { lorem } from 'faker';
 import mockCard from '../Card/Card.mock';
 import mockTheme from '../../theme/mock.theme';
 
 export default {
   itemsSpacing: 2,
   variant: 'collection-three-per-row',
-  items: [{ ...mockCard }, { ...mockCard }, { ...mockCard }, { ...mockCard }, { ...mockCard }],
+  items: [{ ...mockCard }, { ...mockCard, title: lorem.sentence() }, { ...mockCard }, { ...mockCard }],
   itemsVariant: 'standard-round',
   theme: [mockTheme]
 };

--- a/packages/component-library/src/theme/createCardVariants.ts
+++ b/packages/component-library/src/theme/createCardVariants.ts
@@ -173,6 +173,7 @@ export const profileRowCardVariant = (theme: Theme) => ({
       display: 'flex'
     },
     '& .MuiCardContent-root': {
+      height: 'auto !important',
       'padding': theme.spacing(6, 4, 0),
       'textAlign': 'left',
       '&:last-child': {
@@ -241,7 +242,7 @@ export const squareCardVariant = (theme: Theme) => ({
     '& .MuiCardContent-root': {
       'display': 'flex',
       'flexDirection': 'column',
-      'justifyContent': 'center',
+      'justifyContent': 'center !important',
       'alignItems': 'center',
       'height': '100%',
       'padding': '0 16px',
@@ -262,6 +263,9 @@ export const squareCardVariant = (theme: Theme) => ({
       display: 'none'
     },
     '& .MuiTypography-h4': {
+      display: 'none'
+    },
+    '& .MuiBox-root': {
       display: 'none'
     },
     '& .MuiTypography-body1': {
@@ -350,6 +354,7 @@ export const standardBlogCardVariant = (theme: Theme) => ({
   },
   style: {
     'justifyContent': 'flex-start',
+    width: '100%',
     'transition': 'background-color ease .15s',
 
     '& .MuiCardContent-root': {

--- a/packages/component-library/src/theme/createCollectionVariants.ts
+++ b/packages/component-library/src/theme/createCollectionVariants.ts
@@ -19,9 +19,23 @@ export const collectionTwoPerRowVariant = (_: Theme) => ({
   },
   style: {
     '& [class*="Section-root"] > [class*="Section-gridContainer"]': {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, 1fr)',
+      gridAutoRows: '1fr',
+      gridGap: '15px',
       '& > [class*="Section-gridItem"]': {
         flex: '0 0 50%',
-        maxWidth: 1296 / 2
+        maxWidth: 1296 / 2,
+        height: '100%',
+        '& [class*="MuiCardContent-root"]': {
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+          height: '100%'
+        },
+        '& [class*="MuiCardActions-root"]': {
+          marginTop: 'auto'
+        }
       }
     }
   }
@@ -33,8 +47,22 @@ export const collectionThreePerRowVariant = (_: Theme) => ({
   },
   style: {
     '& [class*="Section-root"] > [class*="Section-gridContainer"]': {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      gridAutoRows: '1fr',
+      gridGap: '15px',
       '& > [class*="Section-gridItem"]': {
-        maxWidth: 1296 / 3
+        maxWidth: 1296 / 3,
+        height: '100%',
+        '& [class*="MuiCardContent-root"]': {
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+          height: '100%'
+        },
+        '& [class*="MuiCardActions-root"]': {
+          marginTop: 'auto'
+        }
       }
     }
   }
@@ -51,7 +79,12 @@ export const collectionTilesVariant = (_: Theme) => ({
     'width': '100%',
     'height': '100%',
     '& [class*="Section-root"] > [class*="Section-gridContainer"]': {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      gridAutoRows: '1fr',
+      gridGap: '15px',
       '& > [class*="Section-gridItem"]': {
+        height: '100%',
         margin: 0
       }
     }
@@ -69,12 +102,28 @@ export const collectionThreePerRowRoundedWrapper = (theme: Theme) => ({
     'width': '100%',
     'height': '100%',
     '& [class*="Section-root"] > [class*="Section-gridContainer"]': {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      gridAutoRows: '1fr',
+      gridGap: theme.spacing(3),
+      'padding': theme.spacing(3),
       'border': '2px solid #595959',
       'borderRadius': 40,
       'backgroundColor': theme.palette.quartiary.main,
       'transition': 'background-color ease .15s',
       '& > [class*="Section-gridItem"]': {
-        margin: 0
+        height: '100%',
+        padding: 0,
+        margin: 0,
+        '& [class*="MuiCardContent-root"]': {
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+          height: '100%'
+        },
+        '& [class*="MuiCardActions-root"]': {
+          marginTop: 'auto'
+        }
       }
     },
     '& .MuiPaper-root': {


### PR DESCRIPTION
#### Description

Make cards equal height when grouped

---

##### 🔹 Jira Ticket
https://lastrev.atlassian.net/browse/STRONG-169

##### 🔗 Preview URL:
https://deploy-preview-116--lr-components.netlify.app/?path=/story/1-primitives-mui-collection--default&args=variant:collection-three-per-row-rounded-wrapper


##### 🔬 How to test
* View `Collection`s of `Card`s at different breakpoints
* Heights should be equal to tallest card

##### 📸  Screenshot
<img width="600" alt="cards" src="https://user-images.githubusercontent.com/937917/132737945-f1673ea7-35e7-47c6-9f8e-418ae787dfe0.png">

---
 
##### Changes include
- [x] Bug fix (_non-breaking change that solves an issue_)

 