### PR TITLE
Bug Fix: removed capitalization of contentType in fieldResolver 

### DIFF
--- a/.changeset/purple-balloons-scream.md
+++ b/.changeset/purple-balloons-scream.md
@@ -1,0 +1,6 @@
+---
+'@last-rev/graphql-contentful-core': patch
+'@last-rev/cli': patch
+---
+
+Bug Fix: removed capitalization of contentType in fieldResolver of graphql-contentful-core

--- a/packages/graphql-contentful-core/src/resolvers/fieldResolver.ts
+++ b/packages/graphql-contentful-core/src/resolvers/fieldResolver.ts
@@ -19,11 +19,10 @@ const fieldResolver: FieldResolver = (displayType: string) => async (content, ar
   const { fieldName: field } = info;
   const { loaders, mappers, typeMappings, preview = false } = ctx;
 
-  const contentType = capitalizeFirst(
+  const contentType =
     content && content.sys && content.sys.contentType && content.sys.contentType.sys
       ? content.sys.contentType.sys.id
-      : ''
-  );
+      : '';
   // console.log('resolving field', {
   //   content,
   //   displayType,


### PR DESCRIPTION
Since no live sites are using the type mappings feature, this should not break any of them.

The issue was that typeMappings expects a map of contentTypeId -> newContentTypeId (uieCta -> link, for example) which then gets capitalized to create the typename (Link in the previous example). But we have code in the fieldResolver which capitalizes the contentTypeId, and then tries to look up the type name, and was not finding it. Simple fix is to remove that capitalize code in fieldResolver.