### PR TITLE
Improving customization for the Components Library 

### DIFF
--- a/.changeset/nervous-lies-retire.md
+++ b/.changeset/nervous-lies-retire.md
@@ -1,0 +1,5 @@
+---
+'@last-rev/component-library': patch
+---
+
+added shouldforwardprops and overridesResolver to every styled component

--- a/examples/lastrev-next-starter/package.json
+++ b/examples/lastrev-next-starter/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "workspaces": {
     "packages": [
-      "packages/*"
+      "packages/*",
+      "../../packages/component-library"
     ]
   },
   "scripts": {

--- a/examples/lastrev-next-starter/package.json
+++ b/examples/lastrev-next-starter/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "workspaces": {
     "packages": [
-      "packages/*",
-      "../../packages/component-library"
+      "packages/*"
     ]
   },
   "scripts": {

--- a/examples/lastrev-next-starter/packages/web/package.json
+++ b/examples/lastrev-next-starter/packages/web/package.json
@@ -20,7 +20,7 @@
     "@emotion/react": "^11.7.1",
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.6.0",
-    "@last-rev/component-library": "^0.5.2",
+    "@last-rev/component-library": "^0.5.3",
     "@last-rev/contentful-sidekick-util": "^0.1.1",
     "@last-rev/sitemap-generator": "^0.1.2",
     "@last-rev/testing-library": "^0.1.10",

--- a/packages/component-library/src/components/Accordion/Accordion.tsx
+++ b/packages/component-library/src/components/Accordion/Accordion.tsx
@@ -55,29 +55,29 @@ const AccordionRoot = styled(MuiAccordion, {
 
 const AccordionSummary = styled(MuiAccordionSummary, {
   name: 'Accordion',
-  slot: 'AccordionSummary',
+  slot: 'Summary',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.accordionSummary]
+  overridesResolver: (_, styles) => [styles.summary]
 })``;
 
 const AccordionDetails = styled(MuiAccordionDetails, {
   name: 'Accordion',
-  slot: 'AccordionDetails',
+  slot: 'Details',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.accordionDetails]
+  overridesResolver: (_, styles) => [styles.details]
 })``;
 
 const AccordionTitle = styled(Typography, {
   name: 'Accordion',
-  slot: 'AccordionTitle',
+  slot: 'Title',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.accordionTitle]
+  overridesResolver: (_, styles) => [styles.title]
 })``;
 
 const AccordionBody = styled(ContentModule, {
   name: 'Accordion',
-  slot: 'AccordionBody',
-  overridesResolver: (_, styles) => [styles.accordionBody]
+  slot: 'Body',
+  overridesResolver: (_, styles) => [styles.body]
 })``;
 
 const ExpandMoreIcon = styled(MuiExpandMoreIcon, {

--- a/packages/component-library/src/components/Accordion/Accordion.tsx
+++ b/packages/component-library/src/components/Accordion/Accordion.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
-import { Accordion as MuiAccordion, AccordionProps as MuiAccordionProps, Typography } from '@mui/material';
-import AccordionSummary from '@mui/material/AccordionSummary';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion as MuiAccordion,
+  Typography,
+  AccordionDetails as MuiAccordionDetails,
+  AccordionSummary as MuiAccordionSummary
+} from '@mui/material';
+import MuiExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ErrorBoundary from '../ErrorBoundary';
 import styled from '@mui/system/styled';
 import sidekick from '@last-rev/contentful-sidekick-util';
 import ContentModule from '../ContentModule';
 import { AccordionProps } from './Accordion.types';
-import { TextProps } from '../Text';
 
 export const Accordion = ({ variant, title, body, sidekickLookup, ...props }: AccordionProps) => {
   return (
     <ErrorBoundary>
       <AccordionRoot {...sidekick(sidekickLookup)} variant={variant} data-testid="Accordion" {...props}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <TitleText variant="h4" data-testid="Accordion-title">
+          <AccordionTitle variant="h4" data-testid="Accordion-title">
             {title}
-          </TitleText>
+          </AccordionTitle>
         </AccordionSummary>
         {body ? (
           <AccordionDetails>
-            <TextItem
+            <AccordionBody
               __typename="Text"
               variant="accordion"
               sidekickLookup={sidekickLookup?.body}
@@ -49,18 +51,40 @@ const AccordionRoot = styled(MuiAccordion, {
   slot: 'Root',
   shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root]
-})<MuiAccordionProps & {}>(() => ({}));
-
-const TitleText = styled(Typography, {
-  name: 'Accordion',
-  slot: 'TitleText',
-  overridesResolver: (_, styles) => [styles.titleText]
 })``;
 
-const TextItem = styled(ContentModule, {
+const AccordionSummary = styled(MuiAccordionSummary, {
   name: 'Accordion',
-  slot: 'TextItem',
-  overridesResolver: (_, styles) => [styles.textItem]
-})<TextProps>(() => ({}));
+  slot: 'AccordionSummary',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.accordionSummary]
+})``;
+
+const AccordionDetails = styled(MuiAccordionDetails, {
+  name: 'Accordion',
+  slot: 'AccordionDetails',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.accordionDetails]
+})``;
+
+const AccordionTitle = styled(Typography, {
+  name: 'Accordion',
+  slot: 'AccordionTitle',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.accordionTitle]
+})``;
+
+const AccordionBody = styled(ContentModule, {
+  name: 'Accordion',
+  slot: 'AccordionBody',
+  overridesResolver: (_, styles) => [styles.accordionBody]
+})``;
+
+const ExpandMoreIcon = styled(MuiExpandMoreIcon, {
+  name: 'Accordion',
+  slot: 'ExpandMoreIcon',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.expandMoreIcon]
+})``;
 
 export default Accordion;

--- a/packages/component-library/src/components/Accordion/Accordion.tsx
+++ b/packages/component-library/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Accordion as MuiAccordion,
-  Typography,
+  Typography as MuiTypography,
   AccordionDetails as MuiAccordionDetails,
   AccordionSummary as MuiAccordionSummary
 } from '@mui/material';
@@ -9,7 +9,7 @@ import MuiExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ErrorBoundary from '../ErrorBoundary';
 import styled from '@mui/system/styled';
 import sidekick from '@last-rev/contentful-sidekick-util';
-import ContentModule from '../ContentModule';
+import CModule from '../ContentModule';
 import { AccordionProps } from './Accordion.types';
 
 export const Accordion = ({ variant, title, body, sidekickLookup, ...props }: AccordionProps) => {
@@ -17,13 +17,13 @@ export const Accordion = ({ variant, title, body, sidekickLookup, ...props }: Ac
     <ErrorBoundary>
       <AccordionRoot {...sidekick(sidekickLookup)} variant={variant} data-testid="Accordion" {...props}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <AccordionTitle variant="h4" data-testid="Accordion-title">
+          <Typography variant="h4" data-testid="Accordion-title">
             {title}
-          </AccordionTitle>
+          </Typography>
         </AccordionSummary>
         {body ? (
           <AccordionDetails>
-            <AccordionBody
+            <ContentModule
               __typename="Text"
               variant="accordion"
               sidekickLookup={sidekickLookup?.body}
@@ -67,17 +67,17 @@ const AccordionDetails = styled(MuiAccordionDetails, {
   overridesResolver: (_, styles) => [styles.details]
 })``;
 
-const AccordionTitle = styled(Typography, {
+const Typography = styled(MuiTypography, {
   name: 'Accordion',
-  slot: 'Title',
+  slot: 'Typography',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.title]
+  overridesResolver: (_, styles) => [styles.typography]
 })``;
 
-const AccordionBody = styled(ContentModule, {
+const ContentModule = styled(CModule, {
   name: 'Accordion',
-  slot: 'Body',
-  overridesResolver: (_, styles) => [styles.body]
+  slot: 'ContentModule',
+  overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 
 const ExpandMoreIcon = styled(MuiExpandMoreIcon, {

--- a/packages/component-library/src/components/Accordion/Accordion.tsx
+++ b/packages/component-library/src/components/Accordion/Accordion.tsx
@@ -8,19 +8,20 @@ import styled from '@mui/system/styled';
 import sidekick from '@last-rev/contentful-sidekick-util';
 import ContentModule from '../ContentModule';
 import { AccordionProps } from './Accordion.types';
+import { TextProps } from '../Text';
 
 export const Accordion = ({ variant, title, body, sidekickLookup, ...props }: AccordionProps) => {
   return (
     <ErrorBoundary>
       <AccordionRoot {...sidekick(sidekickLookup)} variant={variant} data-testid="Accordion" {...props}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography variant="h4" data-testid="Accordion-title">
+          <TitleText variant="h4" data-testid="Accordion-title">
             {title}
-          </Typography>
+          </TitleText>
         </AccordionSummary>
         {body ? (
           <AccordionDetails>
-            <ContentModule
+            <TextItem
               __typename="Text"
               variant="accordion"
               sidekickLookup={sidekickLookup?.body}
@@ -49,5 +50,17 @@ const AccordionRoot = styled(MuiAccordion, {
   shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root]
 })<MuiAccordionProps & {}>(() => ({}));
+
+const TitleText = styled(Typography, {
+  name: 'Accordion',
+  slot: 'TitleText',
+  overridesResolver: (_, styles) => [styles.titleText]
+})``;
+
+const TextItem = styled(ContentModule, {
+  name: 'Accordion',
+  slot: 'TextItem',
+  overridesResolver: (_, styles) => [styles.textItem]
+})<TextProps>(() => ({}));
 
 export default Accordion;

--- a/packages/component-library/src/components/Accordion/Accordion.types.ts
+++ b/packages/component-library/src/components/Accordion/Accordion.types.ts
@@ -13,7 +13,7 @@ export interface AccordionProps {
 }
 
 export interface AccordionClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the root element for the Accordion element*/
   root: string;
   /** Styles applied to the root element unless `square={true}`. */
   rounded: string;
@@ -23,17 +23,17 @@ export interface AccordionClasses {
   disabled: string;
   /** Styles applied to the root element unless `disableGutters={true}`. */
   gutters: string;
-  /** Styles applied to the region element, the container of the children. */
+  /** Styles applied to the Region element, the container of the children. */
   region: string;
-  /** Styles applied to the region element, the container of the children. */
-  accordionSummary: string;
-  /** Styles applied to the region element, the container of the children. */
-  accordionDetails: string;
-  /** Styles applied to the region element, the container of the children. */
-  accordionTitle: string;
-  /** Styles applied to the region element, the container of the children. */
-  accordionBody: string;
-  /** Styles applied to the region element, the container of the children. */
+  /** Styles applied to the Summary for the Accordion element. */
+  summary: string;
+  /** Styles applied to the Details for the Accordion element. */
+  details: string;
+  /** Styles applied to the Typography of the title text for the Accordion element. */
+  title: string;
+  /** Styles applied to the Text of the body for the Accordion element. */
+  body: string;
+  /** Styles applied to the ExpandMore Icon for the Accordion element. */
   expandMoreIcon: string;
 }
 export declare type AccordionClassKey = keyof AccordionClasses;

--- a/packages/component-library/src/components/Accordion/Accordion.types.ts
+++ b/packages/component-library/src/components/Accordion/Accordion.types.ts
@@ -13,7 +13,7 @@ export interface AccordionProps {
 }
 
 export interface AccordionClasses {
-  /** Styles applied to the root element for the Accordion element*/
+  /** Styles applied to the root element */
   root: string;
   /** Styles applied to the root element unless `square={true}`. */
   rounded: string;
@@ -25,15 +25,15 @@ export interface AccordionClasses {
   gutters: string;
   /** Styles applied to the Region element, the container of the children. */
   region: string;
-  /** Styles applied to the Summary for the Accordion element. */
+  /** Styles applied to the summary element */
   summary: string;
-  /** Styles applied to the Details for the Accordion element. */
+  /** Styles applied to the details element */
   details: string;
-  /** Styles applied to the Typography of the title text for the Accordion element. */
+  /** Styles applied to the title typography text element */
   title: string;
-  /** Styles applied to the Text of the body for the Accordion element. */
+  /** Styles applied to the body text element */
   body: string;
-  /** Styles applied to the ExpandMore Icon for the Accordion element. */
+  /** Styles applied to the expandMore icon element */
   expandMoreIcon: string;
 }
 export declare type AccordionClassKey = keyof AccordionClasses;

--- a/packages/component-library/src/components/Accordion/Accordion.types.ts
+++ b/packages/component-library/src/components/Accordion/Accordion.types.ts
@@ -25,6 +25,16 @@ export interface AccordionClasses {
   gutters: string;
   /** Styles applied to the region element, the container of the children. */
   region: string;
+  /** Styles applied to the region element, the container of the children. */
+  accordionSummary: string;
+  /** Styles applied to the region element, the container of the children. */
+  accordionDetails: string;
+  /** Styles applied to the region element, the container of the children. */
+  accordionTitle: string;
+  /** Styles applied to the region element, the container of the children. */
+  accordionBody: string;
+  /** Styles applied to the region element, the container of the children. */
+  expandMoreIcon: string;
 }
 export declare type AccordionClassKey = keyof AccordionClasses;
 declare const accordionClasses: AccordionClasses;

--- a/packages/component-library/src/components/Accordion/Accordion.types.ts
+++ b/packages/component-library/src/components/Accordion/Accordion.types.ts
@@ -30,9 +30,9 @@ export interface AccordionClasses {
   /** Styles applied to the details element */
   details: string;
   /** Styles applied to the title typography text element */
-  title: string;
-  /** Styles applied to the body text element */
-  body: string;
+  typography: string;
+  /** Styles applied to the body (Content Module) text element */
+  contentModule: string;
   /** Styles applied to the expandMore icon element */
   expandMoreIcon: string;
 }

--- a/packages/component-library/src/components/AnimatedContentModule/ContentModule.types.ts
+++ b/packages/component-library/src/components/AnimatedContentModule/ContentModule.types.ts
@@ -16,5 +16,5 @@ export interface ContentModuleClasses {
 }
 
 export declare type ContentModuleClassKey = keyof ContentModuleClasses;
-declare const accordionClasses: ContentModuleClasses;
-export default accordionClasses;
+declare const contentModuleClasses: ContentModuleClasses;
+export default contentModuleClasses;

--- a/packages/component-library/src/components/ArtDirectedImage/ArtDirectedImage.tsx
+++ b/packages/component-library/src/components/ArtDirectedImage/ArtDirectedImage.tsx
@@ -74,7 +74,8 @@ const shouldForwardProp = (prop: string) => prop !== 'displaymedia';
 const ResponsiveImage = styled(Image, {
   name: 'ArtDirectedImage',
   slot: 'Root',
-  shouldForwardProp
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.root]
 })<{
   media?: string;
 }>`

--- a/packages/component-library/src/components/ArtDirectedImage/ArtDirectedImage.types.ts
+++ b/packages/component-library/src/components/ArtDirectedImage/ArtDirectedImage.types.ts
@@ -16,5 +16,5 @@ export interface ArtDirectedImageClasses {
   root: string;
 }
 export declare type ArtDirectedImageClassKey = keyof ArtDirectedImageClasses;
-declare const accordionClasses: ArtDirectedImageClasses;
-export default accordionClasses;
+declare const artDirectedImageClasses: ArtDirectedImageClasses;
+export default artDirectedImageClasses;

--- a/packages/component-library/src/components/BackToTop/BackToTop.tsx
+++ b/packages/component-library/src/components/BackToTop/BackToTop.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import MuiKeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import Fab from '@mui/material/Fab';
 import styled from '@mui/system/styled';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
@@ -24,18 +24,19 @@ export const BackToTop = ({ FabProps, sidekickLookup }: BackToTopProps) => {
         onClick={handleClick}
         data-testid="BackToTop"
         aria-label="Back to top"
-        {...sidekick(sidekickLookup)}
-      >
+        {...sidekick(sidekickLookup)}>
         <KeyboardArrowUpIcon />
       </Root>
     </ErrorBoundary>
   );
 };
 
+const shouldForwardProp = (prop: string) => prop !== 'variant' && prop !== 'visible';
+
 const Root = styled(Fab, {
   name: 'BackToTop',
   slot: 'Root',
-  shouldForwardProp: (prop) => prop !== 'visible',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root]
 })<{ variant?: string; visible?: boolean }>`
   position: fixed;
@@ -47,5 +48,12 @@ const Root = styled(Fab, {
   transform: translateY(${visible ? 0 : 100}px);
   `};
 `;
+
+const KeyboardArrowUpIcon = styled(MuiKeyboardArrowUpIcon, {
+  name: 'Card',
+  slot: 'KeyboardArrowUpIcon',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.keyboardArrowUpIcon]
+})``;
 
 export default BackToTop;

--- a/packages/component-library/src/components/BackToTop/BackToTop.types.ts
+++ b/packages/component-library/src/components/BackToTop/BackToTop.types.ts
@@ -9,6 +9,8 @@ export interface BackToTopProps {
 export interface BackToTopClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the keyboardArrowUpIcon element. */
+  keyboardArrowUpIcon: string;
 }
 
 export declare type BackToTopClassKey = keyof BackToTopClasses;

--- a/packages/component-library/src/components/BackToTop/BackToTop.types.ts
+++ b/packages/component-library/src/components/BackToTop/BackToTop.types.ts
@@ -14,5 +14,5 @@ export interface BackToTopClasses {
 }
 
 export declare type BackToTopClassKey = keyof BackToTopClasses;
-declare const accordionClasses: BackToTopClasses;
-export default accordionClasses;
+declare const backToTopClasses: BackToTopClasses;
+export default backToTopClasses;

--- a/packages/component-library/src/components/Card/Card.tsx
+++ b/packages/component-library/src/components/Card/Card.tsx
@@ -78,25 +78,25 @@ export const Card = (inProps: CardProps) => {
             {actions?.length ? (
               <CardActions {...sidekick(sidekickLookup?.actions)} data-testid="Card-actions">
                 {actions?.map((link) => (
-                  <CardButtons __typename="Link" key={link.id} {...link} />
+                  <CardButton __typename="Link" key={link.id} {...link} />
                 ))}
               </CardActions>
             ) : null}
           </CardContent>
         ) : null}
         {loading ? (
-          <CardContentForSkeleton data-testid="Card-ContentSkeleton">
-            <CardTitleForSkeleton variant="h3">
+          <CardContent data-testid="Card-ContentSkeleton">
+            <CardTitle variant="h3">
               <TitleSkeleton width="100%" />
-            </CardTitleForSkeleton>
-            <CardSubtitleForSkeleton variant="h4">
+            </CardTitle>
+            <CardSubtitle variant="h4">
               <SubtitleSkeleton width="100%" />
               <br />
               <SubtitleSkeleton width="100%" />
-            </CardSubtitleForSkeleton>
+            </CardSubtitle>
             <TextSkeleton>
               {body ? (
-                <CardTextForSkeleton
+                <CardBody
                   __typename="Text"
                   variant="card"
                   sidekickLookup={sidekickLookup?.body}
@@ -105,10 +105,10 @@ export const Card = (inProps: CardProps) => {
                 />
               ) : null}
             </TextSkeleton>
-            <CardActionsForSkeleton>
+            <CardActions>
               <ActionsSkeleton width={50} />
-            </CardActionsForSkeleton>
-          </CardContentForSkeleton>
+            </CardActions>
+          </CardContent>
         ) : null}
       </Root>
     </ErrorBoundary>
@@ -146,9 +146,8 @@ const Root = styled(MuiCard, {
 
 const CardLink = styled(ContentModule, {
   name: 'Card',
-  slot: 'CardLink',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardLink]
+  slot: 'Link',
+  overridesResolver: (_, styles) => [styles.link]
 })<LinkProps & {}>`
   position: absolute;
   top: 0;
@@ -159,15 +158,14 @@ const CardLink = styled(ContentModule, {
 
 const CardMedia = styled(MuiCardMedia, {
   name: 'Card',
-  slot: 'CardMedia',
+  slot: 'MediaRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardMedia]
+  overridesResolver: (_, styles) => [styles.mediaRoot]
 })``;
 
 const Media = styled(ContentModule, {
   name: 'Card',
   slot: 'Media',
-  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.media]
 })``;
 
@@ -182,7 +180,7 @@ const CardTags = styled(Box, {
   name: 'Card',
   slot: 'Tags',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardTags]
+  overridesResolver: (_, styles) => [styles.tags]
 })<{}>`
   width: 100%;
   display: flex;
@@ -199,86 +197,46 @@ const Chip = styled(MuiChip, {
 
 const CardTagRoot = styled(ContentModule, {
   name: 'Card',
-  slot: 'CardTagRoot',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardTagRoot]
+  slot: 'TagRoot',
+  overridesResolver: (_, styles) => [styles.tagRoot]
 })``;
 
 const CardContent = styled(MuiCardContent, {
   name: 'Card',
-  slot: 'CardContent',
+  slot: 'Content',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardContent]
+  overridesResolver: (_, styles) => [styles.content]
 })``;
 
 const CardTitle = styled(Typography, {
   name: 'Card',
-  slot: 'CardTitle',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardTitle]
+  slot: 'Title',
+  overridesResolver: (_, styles) => [styles.title]
 })``;
 
 const CardSubtitle = styled(Typography, {
   name: 'Card',
-  slot: 'CardSubtitle',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardSubtitle]
+  slot: 'Subtitle',
+  overridesResolver: (_, styles) => [styles.subtitle]
 })``;
 
 const CardBody = styled(ContentModule, {
   name: 'Card',
-  slot: 'CardBody',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardBody]
+  slot: 'Body',
+  overridesResolver: (_, styles) => [styles.body]
 })``;
 
 const CardActions = styled(MuiCardActions, {
   name: 'Card',
-  slot: 'CardActions',
+  slot: 'Actions',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardActions]
+  overridesResolver: (_, styles) => [styles.actions]
 })``;
 
-const CardButtons = styled(ContentModule, {
+const CardButton = styled(ContentModule, {
   name: 'Card',
-  slot: 'CardButtons',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardButtons]
-})``;
-
-const CardContentForSkeleton = styled(MuiCardContent, {
-  name: 'Card',
-  slot: 'CardContentForSkeleton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardContentForSkeleton]
-})``;
-
-const CardTitleForSkeleton = styled(Typography, {
-  name: 'Card',
-  slot: 'CardTitleForSkeleton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardTitleForSkeleton]
-})``;
-
-const CardSubtitleForSkeleton = styled(Typography, {
-  name: 'Card',
-  slot: 'CardSubtitleForSkeleton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardSubtitleForSkeleton]
-})``;
-
-const CardTextForSkeleton = styled(ContentModule, {
-  name: 'Card',
-  slot: 'CardTextForSkeleton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardTextForSkeleton]
-})``;
-
-const CardActionsForSkeleton = styled(MuiCardActions, {
-  name: 'Card',
-  slot: 'CardActionsForSkeleton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardActionsForSkeleton]
+  slot: 'Button',
+  overridesResolver: (_, styles) => [styles.button]
 })``;
 
 const TitleSkeleton = styled(MuiSkeleton, {

--- a/packages/component-library/src/components/Card/Card.tsx
+++ b/packages/component-library/src/components/Card/Card.tsx
@@ -3,17 +3,16 @@ import {
   Box,
   Card as MuiCard,
   CardProps as MuiCardProps,
-  CardMedia,
-  CardActions,
-  CardContent,
+  CardMedia as MuiCardMedia,
+  CardActions as MuiCardActions,
+  CardContent as MuiCardContent,
   Typography,
-  Chip
+  Chip as MuiChip
 } from '@mui/material';
 import styled from '@mui/system/styled';
-import Skeleton from '@mui/material/Skeleton';
+import MuiSkeleton from '@mui/material/Skeleton';
 
 import ErrorBoundary from '../ErrorBoundary';
-
 import { LinkProps } from '../Link';
 import ContentModule from '../ContentModule';
 import sidekick from '@last-rev/contentful-sidekick-util';
@@ -35,7 +34,7 @@ export const Card = (inProps: CardProps) => {
         {media || loading ? (
           <CardMedia sx={{ display: 'block', position: 'relative', width: '100%' }}>
             {!loading ? (
-              <ContentModule
+              <Media
                 __typename="Media"
                 {...sidekick(sidekickLookup?.media)}
                 {...getFirstOfArray(media)}
@@ -43,7 +42,7 @@ export const Card = (inProps: CardProps) => {
               />
             ) : (
               <Skeleton>
-                <ContentModule {...sidekick(sidekickLookup?.media)} {...getFirstOfArray(media)} testId="Card-media" />
+                <Media {...sidekick(sidekickLookup?.media)} {...getFirstOfArray(media)} testId="Card-media" />
               </Skeleton>
             )}
           </CardMedia>
@@ -55,7 +54,6 @@ export const Card = (inProps: CardProps) => {
             ))}
           </CardTags>
         ) : null}
-
         {!loading && (title || subtitle || body || actions) ? (
           <CardContent>
             {title ? (
@@ -92,17 +90,17 @@ export const Card = (inProps: CardProps) => {
         ) : null}
         {loading ? (
           <CardContent data-testid="Card-ContentSkeleton">
-            <Typography variant="h3" component="h3">
+            <CardTextSkeleton variant="h3">
               <Skeleton width="100%" />
-            </Typography>
-            <Typography variant="h4" component="h4">
+            </CardTextSkeleton>
+            <CardTextSkeleton variant="h4">
               <Skeleton width="100%" />
               <br />
               <Skeleton width="100%" />
-            </Typography>
+            </CardTextSkeleton>
             <Skeleton>
               {body ? (
-                <ContentModule
+                <CardBody
                   __typename="Text"
                   variant="card"
                   sidekickLookup={sidekickLookup?.body}
@@ -130,8 +128,6 @@ const CardTag = ({ href, text }: LinkProps) =>
     </CardTagRoot>
   );
 
-const CardTagRoot = styled(ContentModule, { name: 'Card', slot: 'TagRoot' })``;
-
 const shouldForwardProp = (prop: string) =>
   prop !== 'variant' &&
   prop !== 'sidekickLookup' &&
@@ -151,17 +147,6 @@ const Root = styled(MuiCard, {
 })<MuiCardProps & {}>`
   position: relative;
 `;
-const CardTags = styled(Box, {
-  name: 'Card',
-  slot: 'Tags',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardTags]
-})<{}>`
-  width: 100%;
-  display: flex;
-  gap: ${({ theme }) => theme.spacing(1)};
-  padding: ${({ theme }) => theme.spacing(2)};
-`;
 
 const CardLink = styled(ContentModule, {
   name: 'Card',
@@ -175,5 +160,80 @@ const CardLink = styled(ContentModule, {
   width: 100%;
   height: 100%;
 `;
+
+const CardMedia = styled(MuiCardMedia, {
+  name: 'Card',
+  slot: 'CardMedia',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardMedia]
+})``;
+
+const Skeleton = styled(MuiSkeleton, {
+  name: 'Card',
+  slot: 'Skeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.skeleton]
+})``;
+
+const Media = styled(ContentModule, {
+  name: 'Card',
+  slot: 'Media',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.media]
+})``;
+
+const Chip = styled(MuiChip, {
+  name: 'Card',
+  slot: 'Chip',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.chip]
+})``;
+
+const CardTags = styled(Box, {
+  name: 'Card',
+  slot: 'Tags',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardTags]
+})<{}>`
+  width: 100%;
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(1)};
+  padding: ${({ theme }) => theme.spacing(2)};
+`;
+
+const CardTagRoot = styled(ContentModule, {
+  name: 'Card',
+  slot: 'CardTagRoot',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardTagRoot]
+})``;
+
+const CardContent = styled(MuiCardContent, {
+  name: 'Card',
+  slot: 'CardContent',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardContent]
+})``;
+
+const CardTextSkeleton = styled(Typography, {
+  name: 'Card',
+  slot: 'CardTextSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardTextSkeleton]
+})``;
+
+const CardBody = styled(ContentModule, {
+  name: 'Card',
+  slot: 'CardBody',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardBody]
+})``;
+
+const CardActions = styled(MuiCardActions, {
+  name: 'Card',
+  slot: 'CardActions',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardActions]
+})``;
 
 export default Card;

--- a/packages/component-library/src/components/Card/Card.tsx
+++ b/packages/component-library/src/components/Card/Card.tsx
@@ -26,19 +26,11 @@ export const Card = (inProps: CardProps) => {
     name: 'Card',
     props: inProps
   });
-  const { media, title, subtitle, body, link, tags, actions, variant, loading, styles, sidekickLookup } = props;
-  console.log({ styles });
-  console.log('hola');
+  const { media, title, subtitle, body, link, tags, actions, variant, loading, sidekickLookup } = props;
+
   return (
     <ErrorBoundary>
-      <Root
-        variant={variant}
-        data-testid="Card"
-        sx={{
-          ...styles?.root
-        }}
-        {...sidekick(sidekickLookup)}
-        {...(props as any)}>
+      <Root variant={variant} data-testid="Card" {...sidekick(sidekickLookup)} {...(props as any)}>
         {!!link ? <CardLink __typename="Link" noLinkStyle {...(link as any)} /> : null}
         {media || loading ? (
           <CardMedia sx={{ display: 'block', position: 'relative', width: '100%' }}>

--- a/packages/component-library/src/components/Card/Card.tsx
+++ b/packages/component-library/src/components/Card/Card.tsx
@@ -71,7 +71,7 @@ export const Card = (inProps: CardProps) => {
               </Typography>
             ) : null}
             {body ? (
-              <ContentModule
+              <CardBody
                 __typename="Text"
                 variant="card"
                 sidekickLookup={sidekickLookup?.body}
@@ -82,7 +82,7 @@ export const Card = (inProps: CardProps) => {
             {actions?.length ? (
               <CardActions {...sidekick(sidekickLookup?.actions)} data-testid="Card-actions">
                 {actions?.map((link) => (
-                  <ContentModule __typename="Link" key={link.id} {...link} />
+                  <CardButtons __typename="Link" key={link.id} {...link} />
                 ))}
               </CardActions>
             ) : null}
@@ -227,6 +227,13 @@ const CardBody = styled(ContentModule, {
   slot: 'CardBody',
   shouldForwardProp,
   overridesResolver: (_, styles) => [styles.cardBody]
+})``;
+
+const CardButtons = styled(ContentModule, {
+  name: 'Card',
+  slot: 'CardButtons',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardButtons]
 })``;
 
 const CardActions = styled(MuiCardActions, {

--- a/packages/component-library/src/components/Card/Card.tsx
+++ b/packages/component-library/src/components/Card/Card.tsx
@@ -41,9 +41,9 @@ export const Card = (inProps: CardProps) => {
                 data-testid="Card-media"
               />
             ) : (
-              <Skeleton>
+              <MediaSkeleton>
                 <Media {...sidekick(sidekickLookup?.media)} {...getFirstOfArray(media)} testId="Card-media" />
-              </Skeleton>
+              </MediaSkeleton>
             )}
           </CardMedia>
         ) : null}
@@ -57,18 +57,14 @@ export const Card = (inProps: CardProps) => {
         {!loading && (title || subtitle || body || actions) ? (
           <CardContent>
             {title ? (
-              <Typography {...sidekick(sidekickLookup?.title)} variant="h3" component="h3" data-testid="Card-title">
+              <CardTitle {...sidekick(sidekickLookup?.title)} variant="h3" data-testid="Card-title">
                 {title}
-              </Typography>
+              </CardTitle>
             ) : null}
             {subtitle ? (
-              <Typography
-                {...sidekick(sidekickLookup?.subtitle)}
-                variant="h4"
-                component="h4"
-                data-testid="Card-subtitle">
+              <CardSubtitle {...sidekick(sidekickLookup?.subtitle)} variant="h4" data-testid="Card-subtitle">
                 {subtitle}
-              </Typography>
+              </CardSubtitle>
             ) : null}
             {body ? (
               <CardBody
@@ -89,18 +85,18 @@ export const Card = (inProps: CardProps) => {
           </CardContent>
         ) : null}
         {loading ? (
-          <CardContent data-testid="Card-ContentSkeleton">
-            <CardTextSkeleton variant="h3">
-              <Skeleton width="100%" />
-            </CardTextSkeleton>
-            <CardTextSkeleton variant="h4">
-              <Skeleton width="100%" />
+          <CardContentForSkeleton data-testid="Card-ContentSkeleton">
+            <CardTitleForSkeleton variant="h3">
+              <TitleSkeleton width="100%" />
+            </CardTitleForSkeleton>
+            <CardSubtitleForSkeleton variant="h4">
+              <SubtitleSkeleton width="100%" />
               <br />
-              <Skeleton width="100%" />
-            </CardTextSkeleton>
-            <Skeleton>
+              <SubtitleSkeleton width="100%" />
+            </CardSubtitleForSkeleton>
+            <TextSkeleton>
               {body ? (
-                <CardBody
+                <CardTextForSkeleton
                   __typename="Text"
                   variant="card"
                   sidekickLookup={sidekickLookup?.body}
@@ -108,11 +104,11 @@ export const Card = (inProps: CardProps) => {
                   data-testid="Card-body"
                 />
               ) : null}
-            </Skeleton>
-            <CardActions>
-              <Skeleton width={50} />
-            </CardActions>
-          </CardContent>
+            </TextSkeleton>
+            <CardActionsForSkeleton>
+              <ActionsSkeleton width={50} />
+            </CardActionsForSkeleton>
+          </CardContentForSkeleton>
         ) : null}
       </Root>
     </ErrorBoundary>
@@ -168,13 +164,6 @@ const CardMedia = styled(MuiCardMedia, {
   overridesResolver: (_, styles) => [styles.cardMedia]
 })``;
 
-const Skeleton = styled(MuiSkeleton, {
-  name: 'Card',
-  slot: 'Skeleton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.skeleton]
-})``;
-
 const Media = styled(ContentModule, {
   name: 'Card',
   slot: 'Media',
@@ -182,11 +171,11 @@ const Media = styled(ContentModule, {
   overridesResolver: (_, styles) => [styles.media]
 })``;
 
-const Chip = styled(MuiChip, {
+const MediaSkeleton = styled(MuiSkeleton, {
   name: 'Card',
-  slot: 'Chip',
+  slot: 'MediaSkeleton',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.chip]
+  overridesResolver: (_, styles) => [styles.mediaSkeleton]
 })``;
 
 const CardTags = styled(Box, {
@@ -200,6 +189,13 @@ const CardTags = styled(Box, {
   gap: ${({ theme }) => theme.spacing(1)};
   padding: ${({ theme }) => theme.spacing(2)};
 `;
+
+const Chip = styled(MuiChip, {
+  name: 'Card',
+  slot: 'Chip',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.chip]
+})``;
 
 const CardTagRoot = styled(ContentModule, {
   name: 'Card',
@@ -215,11 +211,18 @@ const CardContent = styled(MuiCardContent, {
   overridesResolver: (_, styles) => [styles.cardContent]
 })``;
 
-const CardTextSkeleton = styled(Typography, {
+const CardTitle = styled(Typography, {
   name: 'Card',
-  slot: 'CardTextSkeleton',
+  slot: 'CardTitle',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardTextSkeleton]
+  overridesResolver: (_, styles) => [styles.cardTitle]
+})``;
+
+const CardSubtitle = styled(Typography, {
+  name: 'Card',
+  slot: 'CardSubtitle',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardSubtitle]
 })``;
 
 const CardBody = styled(ContentModule, {
@@ -229,6 +232,13 @@ const CardBody = styled(ContentModule, {
   overridesResolver: (_, styles) => [styles.cardBody]
 })``;
 
+const CardActions = styled(MuiCardActions, {
+  name: 'Card',
+  slot: 'CardActions',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardActions]
+})``;
+
 const CardButtons = styled(ContentModule, {
   name: 'Card',
   slot: 'CardButtons',
@@ -236,11 +246,67 @@ const CardButtons = styled(ContentModule, {
   overridesResolver: (_, styles) => [styles.cardButtons]
 })``;
 
-const CardActions = styled(MuiCardActions, {
+const CardContentForSkeleton = styled(MuiCardContent, {
   name: 'Card',
-  slot: 'CardActions',
+  slot: 'CardContentForSkeleton',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.cardActions]
+  overridesResolver: (_, styles) => [styles.cardContentForSkeleton]
+})``;
+
+const CardTitleForSkeleton = styled(Typography, {
+  name: 'Card',
+  slot: 'CardTitleForSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardTitleForSkeleton]
+})``;
+
+const CardSubtitleForSkeleton = styled(Typography, {
+  name: 'Card',
+  slot: 'CardSubtitleForSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardSubtitleForSkeleton]
+})``;
+
+const CardTextForSkeleton = styled(ContentModule, {
+  name: 'Card',
+  slot: 'CardTextForSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardTextForSkeleton]
+})``;
+
+const CardActionsForSkeleton = styled(MuiCardActions, {
+  name: 'Card',
+  slot: 'CardActionsForSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.cardActionsForSkeleton]
+})``;
+
+const TitleSkeleton = styled(MuiSkeleton, {
+  name: 'Card',
+  slot: 'TitleSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.titleSkeleton]
+})``;
+
+const SubtitleSkeleton = styled(MuiSkeleton, {
+  name: 'Card',
+  slot: 'SubtitleSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.subtitleSkeleton]
+})``;
+
+const TextSkeleton = styled(MuiSkeleton, {
+  name: 'Card',
+  slot: 'TextSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.textSkeleton]
+})``;
+
+const ActionsSkeleton = styled(MuiSkeleton, {
+  name: 'Card',
+  slot: 'ActionsSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.actionsSkeleton]
 })``;
 
 export default Card;

--- a/packages/component-library/src/components/Card/Card.tsx
+++ b/packages/component-library/src/components/Card/Card.tsx
@@ -26,10 +26,19 @@ export const Card = (inProps: CardProps) => {
     name: 'Card',
     props: inProps
   });
-  const { media, title, subtitle, body, link, tags, actions, variant, loading, sidekickLookup } = props;
+  const { media, title, subtitle, body, link, tags, actions, variant, loading, styles, sidekickLookup } = props;
+  console.log({ styles });
+  console.log('hola');
   return (
     <ErrorBoundary>
-      <Root variant={variant} data-testid="Card" {...sidekick(sidekickLookup)} {...(props as any)}>
+      <Root
+        variant={variant}
+        data-testid="Card"
+        sx={{
+          ...styles?.root
+        }}
+        {...sidekick(sidekickLookup)}
+        {...(props as any)}>
         {!!link ? <CardLink __typename="Link" noLinkStyle {...(link as any)} /> : null}
         {media || loading ? (
           <CardMedia sx={{ display: 'block', position: 'relative', width: '100%' }}>
@@ -67,8 +76,7 @@ export const Card = (inProps: CardProps) => {
                 {...sidekick(sidekickLookup?.subtitle)}
                 variant="h4"
                 component="h4"
-                data-testid="Card-subtitle"
-              >
+                data-testid="Card-subtitle">
                 {subtitle}
               </Typography>
             ) : null}

--- a/packages/component-library/src/components/Card/Card.types.ts
+++ b/packages/component-library/src/components/Card/Card.types.ts
@@ -27,50 +27,42 @@ export interface CardProps extends Omit<MuiCardProps, 'variant'> {
 }
 
 export interface CardClasses {
-  /** Styles applied to the Root element. */
+  /** Styles applied to the Root for the Card element. */
   root: string;
-  /** Styles applied to the Card Link element. */
-  cardLink: string;
-  /** Styles applied to the Card Media element. */
-  cardMedia: string;
-  /** Styles applied to the Media ContentModule element. */
+  /** Styles applied to the Link for the Card element. */
+  link: string;
+  /** Styles applied to the MediaRoot for the Card element. */
+  mediaRoot: string;
+  /** Styles applied to the Media ContentModule for the Card element. */
   media: string;
-  /** Styles applied to the Media Skeleton element. */
+  /** Styles applied to the Media Skeleton for the Card element. */
   mediaSkeleton: string;
-  /** Styles applied to the CardTagsRoot Container element. */
-  cardTags: string;
-  /** Styles applied to the Card Chip element. */
+  /** Styles applied to the Root of the Tags for the Card element. */
+  tags: string;
+  /** Styles applied to the Chip/Tag Element for the Card element. */
   chip: string;
-  /** Styles applied to the CardTag element. */
-  cardTagRoot: string;
-  /** Styles applied to the CardContent element. */
-  cardContent: string;
-  /** Styles applied to the Card Title element. */
-  cardTitle: string;
-  /** Styles applied to the Card Subtitle element. */
-  cardSubtitle: string;
-  /** Styles applied to the Card Text ContentModule element. */
-  cardBody: string;
-  /** Styles applied to the Card Actions element. */
-  cardActions: string;
-  /** Styles applied to the Buttons or Links from CardActions element. */
-  cardButtons: string;
-  /** Styles applied to the CardContent used to build the skeleton for the card element. */
-  CardContentForSkeleton: string;
-  /** Styles applied to the Typography used to build the skeleton for the card element. */
-  CardTitleForSkeleton: string;
-  /** Styles applied to the skeleton of the title Typography the for the card element. */
-  TitleSkeleton: string;
-  /** Styles applied to the Typography used to build the skeleton for the card element. */
-  CardSubtitleForSkeleton: string;
-  /** Styles applied to the skeleton of the title Typography the for the card element. */
-  SubtitleSkeleton: string;
-  /** Styles applied to the skeleton of the Text the for the card element. */
-  TextSkeleton: string;
-  /** Styles applied to the CardActions used to build the skeleton for the card element. */
-  CardActionsForSkeleton: string;
-  /** Styles applied to the skeleton of the CardActions the for the card element. */
-  ActionsSkeleton: string;
+  /** Styles applied to the CardTagRoot ContentModule for the Card element. */
+  tagRoot: string;
+  /** Styles applied to the CardContent for the Card element. */
+  content: string;
+  /** Styles applied to the Typography of the title text for the Card element. */
+  title: string;
+  /** Styles applied to the Typography of the subtitle text for the Card element. */
+  subtitle: string;
+  /** Styles applied to the Text of the body for the Card element. */
+  body: string;
+  /** Styles applied to the CardActions for the Card element. */
+  actions: string;
+  /** Styles applied to the ButtonHero for the Card element. */
+  button: string;
+  /** Styles applied to the Skeleton of the title text for the Card element. */
+  titleSkeleton: string;
+  /** Styles applied to the Skeleton of the subtitle text for the Card element. */
+  subtitleSkeleton: string;
+  /** Styles applied to the Skeleton of the body text for the Card element. */
+  textSkeleton: string;
+  /** Styles applied to the Skeleton of the CardActions for the Card element. */
+  actionsSkeleton: string;
 }
 
 export declare type CardClassKey = keyof CardClasses;

--- a/packages/component-library/src/components/Card/Card.types.ts
+++ b/packages/component-library/src/components/Card/Card.types.ts
@@ -27,32 +27,50 @@ export interface CardProps extends Omit<MuiCardProps, 'variant'> {
 }
 
 export interface CardClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the Root element. */
   root: string;
-  /** Styles applied to the card tags root container element. */
-  cardTags: string;
-  /** Styles applied to the card title element. */
-  cardTitle: string;
-  /** Styles applied to the card link element. */
+  /** Styles applied to the Card Link element. */
   cardLink: string;
-  /** Styles applied to the card media element. */
+  /** Styles applied to the Card Media element. */
   cardMedia: string;
-  /** Styles applied to the card skeleton element. */
-  skeleton: string;
-  /** Styles applied to the media content module element. */
+  /** Styles applied to the Media ContentModule element. */
   media: string;
-  /** Styles applied to the card chip element. */
+  /** Styles applied to the Media Skeleton element. */
+  mediaSkeleton: string;
+  /** Styles applied to the CardTagsRoot Container element. */
+  cardTags: string;
+  /** Styles applied to the Card Chip element. */
   chip: string;
-  /** Styles applied to the card tag element. */
+  /** Styles applied to the CardTag element. */
   cardTagRoot: string;
-  /** Styles applied to the card content element. */
+  /** Styles applied to the CardContent element. */
   cardContent: string;
-  /** Styles applied to the typography used to build the skeleton for the card element. */
-  cardTextSkeleton: string;
-  /** Styles applied to the card text content module element. */
+  /** Styles applied to the Card Title element. */
+  cardTitle: string;
+  /** Styles applied to the Card Subtitle element. */
+  cardSubtitle: string;
+  /** Styles applied to the Card Text ContentModule element. */
   cardBody: string;
-  /** Styles applied to the card actions element. */
+  /** Styles applied to the Card Actions element. */
   cardActions: string;
+  /** Styles applied to the Buttons or Links from CardActions element. */
+  cardButtons: string;
+  /** Styles applied to the CardContent used to build the skeleton for the card element. */
+  CardContentForSkeleton: string;
+  /** Styles applied to the Typography used to build the skeleton for the card element. */
+  CardTitleForSkeleton: string;
+  /** Styles applied to the skeleton of the title Typography the for the card element. */
+  TitleSkeleton: string;
+  /** Styles applied to the Typography used to build the skeleton for the card element. */
+  CardSubtitleForSkeleton: string;
+  /** Styles applied to the skeleton of the title Typography the for the card element. */
+  SubtitleSkeleton: string;
+  /** Styles applied to the skeleton of the Text the for the card element. */
+  TextSkeleton: string;
+  /** Styles applied to the CardActions used to build the skeleton for the card element. */
+  CardActionsForSkeleton: string;
+  /** Styles applied to the skeleton of the CardActions the for the card element. */
+  ActionsSkeleton: string;
 }
 
 export declare type CardClassKey = keyof CardClasses;

--- a/packages/component-library/src/components/Card/Card.types.ts
+++ b/packages/component-library/src/components/Card/Card.types.ts
@@ -35,6 +35,24 @@ export interface CardClasses {
   cardTitle: string;
   /** Styles applied to the card link element. */
   cardLink: string;
+  /** Styles applied to the card media element. */
+  cardMedia: string;
+  /** Styles applied to the card skeleton element. */
+  skeleton: string;
+  /** Styles applied to the media content module element. */
+  media: string;
+  /** Styles applied to the card chip element. */
+  chip: string;
+  /** Styles applied to the card tag element. */
+  cardTagRoot: string;
+  /** Styles applied to the card content element. */
+  cardContent: string;
+  /** Styles applied to the typography used to build the skeleton for the card element. */
+  cardTextSkeleton: string;
+  /** Styles applied to the card text content module element. */
+  cardBody: string;
+  /** Styles applied to the card actions element. */
+  cardActions: string;
 }
 
 export declare type CardClassKey = keyof CardClasses;

--- a/packages/component-library/src/components/Card/Card.types.ts
+++ b/packages/component-library/src/components/Card/Card.types.ts
@@ -27,44 +27,44 @@ export interface CardProps extends Omit<MuiCardProps, 'variant'> {
 }
 
 export interface CardClasses {
-  /** Styles applied to the Root for the Card element. */
+  /** Styles applied to the Root element. */
   root: string;
-  /** Styles applied to the Link for the Card element. */
+  /** Styles applied to the Link element. */
   link: string;
-  /** Styles applied to the MediaRoot for the Card element. */
+  /** Styles applied to the MediaRoot element. */
   mediaRoot: string;
-  /** Styles applied to the Media ContentModule for the Card element. */
+  /** Styles applied to the Media ContentModule element. */
   media: string;
-  /** Styles applied to the Media Skeleton for the Card element. */
+  /** Styles applied to the Media Skeleton element. */
   mediaSkeleton: string;
-  /** Styles applied to the Root of the Tags for the Card element. */
+  /** Styles applied to the Root of the Tags element. */
   tags: string;
-  /** Styles applied to the Chip/Tag Element for the Card element. */
+  /** Styles applied to the Chip/Tag Element element. */
   chip: string;
-  /** Styles applied to the CardTagRoot ContentModule for the Card element. */
+  /** Styles applied to the CardTagRoot ContentModule element. */
   tagRoot: string;
-  /** Styles applied to the CardContent for the Card element. */
+  /** Styles applied to the CardContent element. */
   content: string;
-  /** Styles applied to the Typography of the title text for the Card element. */
+  /** Styles applied to the Typography of the title text element. */
   title: string;
-  /** Styles applied to the Typography of the subtitle text for the Card element. */
+  /** Styles applied to the Typography of the subtitle text element. */
   subtitle: string;
-  /** Styles applied to the Text of the body for the Card element. */
+  /** Styles applied to the Text of the body element. */
   body: string;
-  /** Styles applied to the CardActions for the Card element. */
+  /** Styles applied to the CardActions element. */
   actions: string;
-  /** Styles applied to the ButtonHero for the Card element. */
+  /** Styles applied to the ButtonHero element. */
   button: string;
-  /** Styles applied to the Skeleton of the title text for the Card element. */
+  /** Styles applied to the Skeleton of the title text element. */
   titleSkeleton: string;
-  /** Styles applied to the Skeleton of the subtitle text for the Card element. */
+  /** Styles applied to the Skeleton of the subtitle text element. */
   subtitleSkeleton: string;
-  /** Styles applied to the Skeleton of the body text for the Card element. */
+  /** Styles applied to the Skeleton of the body text element. */
   textSkeleton: string;
-  /** Styles applied to the Skeleton of the CardActions for the Card element. */
+  /** Styles applied to the Skeleton of the CardActions element. */
   actionsSkeleton: string;
 }
 
 export declare type CardClassKey = keyof CardClasses;
-declare const accordionClasses: CardClasses;
-export default accordionClasses;
+declare const cardClasses: CardClasses;
+export default cardClasses;

--- a/packages/component-library/src/components/Collection/Collection.types.ts
+++ b/packages/component-library/src/components/Collection/Collection.types.ts
@@ -29,5 +29,5 @@ export interface CollectionClasses {
 }
 
 export declare type CollectionClassKey = keyof CollectionClasses;
-declare const accordionClasses: CollectionClasses;
-export default accordionClasses;
+declare const collectionClasses: CollectionClasses;
+export default collectionClasses;

--- a/packages/component-library/src/components/CollectionAccordion/CollectionAccordion.tsx
+++ b/packages/component-library/src/components/CollectionAccordion/CollectionAccordion.tsx
@@ -22,8 +22,7 @@ export const CollectionAccordion = ({
         spacing={itemSpacing ?? 0}
         {...sidekick(sidekickLookup)}
         variant={variant}
-        data-testid="CollectionAccordion"
-      >
+        data-testid="CollectionAccordion">
         {itemsWithVariant.map((item, idx) => (
           <AccordionItem item key={idx}>
             <Accordion {...item} />
@@ -43,8 +42,8 @@ const Root = styled(Grid, {
 
 const AccordionItem = styled(Grid, {
   name: 'CollectionAccordion',
-  slot: 'AccordionItem',
-  overridesResolver: (_, styles) => [styles.accordionItem]
+  slot: 'item',
+  overridesResolver: (_, styles) => [styles.item]
 })<{ variant?: string }>`
   width: 100%;
 `;

--- a/packages/component-library/src/components/CollectionAccordion/CollectionAccordion.types.ts
+++ b/packages/component-library/src/components/CollectionAccordion/CollectionAccordion.types.ts
@@ -12,8 +12,8 @@ export interface CollectionAccordionProps {
 export interface CollectionAccordionClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to every accordion item */
-  accordionItem: string;
+  /** Styles applied to each accordion item */
+  item: string;
 }
 
 export declare type CollectionAccordionClassKey = keyof CollectionAccordionClasses;

--- a/packages/component-library/src/components/CollectionAccordion/CollectionAccordion.types.ts
+++ b/packages/component-library/src/components/CollectionAccordion/CollectionAccordion.types.ts
@@ -12,10 +12,10 @@ export interface CollectionAccordionProps {
 export interface CollectionAccordionClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to each accordion item */
+  /** Styles applied to each accordion item element */
   item: string;
 }
 
 export declare type CollectionAccordionClassKey = keyof CollectionAccordionClasses;
-declare const accordionClasses: CollectionAccordionClasses;
-export default accordionClasses;
+declare const collectionAccordionClasses: CollectionAccordionClasses;
+export default collectionAccordionClasses;

--- a/packages/component-library/src/components/CollectionAccordionMedia/CollectionAccordionMedia.tsx
+++ b/packages/component-library/src/components/CollectionAccordionMedia/CollectionAccordionMedia.tsx
@@ -25,8 +25,7 @@ export const CollectionAccordionMedia = ({
         spacing={itemsSpacing ?? 0}
         {...sidekick(sidekickLookup)}
         variant={variant}
-        data-testid="CollectionAccordionMedia"
-      >
+        data-testid="CollectionAccordionMedia">
         <SelectedMediaRoot>
           <SelectedMedia
             __typename="Media"
@@ -70,7 +69,6 @@ const SelectedMediaRoot = styled(Grid, {
 const SelectedMedia = styled(ContentModule, {
   name: 'CollectionAccordionMedia',
   slot: 'SelectedMedia',
-  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.selectedMedia]
 })``;
 

--- a/packages/component-library/src/components/CollectionAccordionMedia/CollectionAccordionMedia.types.ts
+++ b/packages/component-library/src/components/CollectionAccordionMedia/CollectionAccordionMedia.types.ts
@@ -7,18 +7,18 @@ export interface CollectionAccordionMediaProps extends CollectionProps {
 }
 
 export interface CollectionAccordionMediaClasses {
-  /** Styles applied to the root element for the CollectionAccordionMedia element*/
+  /** Styles applied to the root element element*/
   root: string;
-  /** Styles applied to the accordionRoot for the CollectionAccordionMedia element. */
+  /** Styles applied to the accordionRoot element. */
   accordionRoot: string;
-  /** Styles applied to the selectedMediaRoot for the CollectionAccordionMedia element. */
+  /** Styles applied to the selectedMediaRoot element. */
   selectedMediaRoot: string;
-  /** Styles applied to the SelectedMedia ContentModule for the CollectionAccordionMedia element. */
+  /** Styles applied to the SelectedMedia ContentModule element. */
   selectedMedia: string;
-  /** Styles applied to the accordionItem for the CollectionAccordionMedia element. */
+  /** Styles applied to the accordionItem element. */
   accordionItem: string;
 }
 
 export declare type CollectionAccordionMediaClassKey = keyof CollectionAccordionMediaClasses;
-declare const accordionClasses: CollectionAccordionMediaClasses;
-export default accordionClasses;
+declare const collectionAccordionMediaClasses: CollectionAccordionMediaClasses;
+export default collectionAccordionMediaClasses;

--- a/packages/component-library/src/components/CollectionAccordionMedia/CollectionAccordionMedia.types.ts
+++ b/packages/component-library/src/components/CollectionAccordionMedia/CollectionAccordionMedia.types.ts
@@ -7,15 +7,15 @@ export interface CollectionAccordionMediaProps extends CollectionProps {
 }
 
 export interface CollectionAccordionMediaClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the root element for the CollectionAccordionMedia element*/
   root: string;
-  /** Styles applied to the accordionRoot element. */
+  /** Styles applied to the accordionRoot for the CollectionAccordionMedia element. */
   accordionRoot: string;
-  /** Styles applied to the selectedMediaRoot element. */
+  /** Styles applied to the selectedMediaRoot for the CollectionAccordionMedia element. */
   selectedMediaRoot: string;
-  /** Styles applied to the selectedMedia element. */
+  /** Styles applied to the SelectedMedia ContentModule for the CollectionAccordionMedia element. */
   selectedMedia: string;
-  /** Styles applied to the accordionItem element. */
+  /** Styles applied to the accordionItem for the CollectionAccordionMedia element. */
   accordionItem: string;
 }
 

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
@@ -5,7 +5,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import SwiperCore, { Navigation, Pagination, A11y } from 'swiper/core';
 
 import ErrorBoundary from '../ErrorBoundary';
-import ContentModule from '../ContentModule';
+import CModule from '../ContentModule';
 import sidekick from '@last-rev/contentful-sidekick-util';
 import { CollectionCarouselProps } from './CollectionCarousel.types';
 
@@ -23,17 +23,18 @@ export const CollectionCarousel = ({
   const itemsWithVariant = items.map((item) => ({ ...item, variant: itemsVariant ?? item?.variant }));
 
   const config = CarouselVariantProps[variant];
+
   return (
     <ErrorBoundary>
       <Root {...sidekick(sidekickLookup)} variant={variant} data-testid="CollectionCarousel">
         <ContentContainer maxWidth={itemsWidth} disableGutters>
           <CarouselContainer navigation pagination={{ clickable: true }} loop {...config}>
             {itemsWithVariant.map((item, idx) => (
-              <CarouselSlideRoot key={idx}>
-                <CarouselSlide>
-                  <CarouselContent {...item} sx={undefined} />
-                </CarouselSlide>
-              </CarouselSlideRoot>
+              <SwiperSlide key={idx}>
+                <CarouselItem>
+                  <ContentModule {...item} sx={undefined} />
+                </CarouselItem>
+              </SwiperSlide>
             ))}
           </CarouselContainer>
         </ContentContainer>
@@ -82,18 +83,11 @@ const CarouselContainer = styled(Swiper, {
   }
 }));
 
-const CarouselSlideRoot = styled(SwiperSlide, {
+const CarouselItem = styled(Box, {
   name: 'CollectionCarousel',
-  slot: 'SlideRoot',
+  slot: 'Item',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.slideRoot]
-})``;
-
-const CarouselSlide = styled(Box, {
-  name: 'CollectionCarousel',
-  slot: 'Slide',
-  shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.slide]
+  overridesResolver: (_, styles) => [styles.item]
 })<{ variant?: string }>(() => ({
   display: 'flex',
   justifyContent: 'center',
@@ -102,10 +96,10 @@ const CarouselSlide = styled(Box, {
   width: '100%'
 }));
 
-const CarouselContent = styled(ContentModule, {
+const ContentModule = styled(CModule, {
   name: 'CollectionCarousel',
-  slot: 'Content',
-  overridesResolver: (_, styles) => [styles.content]
+  slot: 'ContentModule',
+  overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 
 export default CollectionCarousel;

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
@@ -23,7 +23,6 @@ export const CollectionCarousel = ({
   const itemsWithVariant = items.map((item) => ({ ...item, variant: itemsVariant ?? item?.variant }));
 
   const config = CarouselVariantProps[variant];
-  console.log({ items });
   return (
     <ErrorBoundary>
       <Root {...sidekick(sidekickLookup)} variant={variant} data-testid="CollectionCarousel">

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
@@ -23,18 +23,18 @@ export const CollectionCarousel = ({
   const itemsWithVariant = items.map((item) => ({ ...item, variant: itemsVariant ?? item?.variant }));
 
   const config = CarouselVariantProps[variant];
-
+  console.log({ items });
   return (
     <ErrorBoundary>
       <Root {...sidekick(sidekickLookup)} variant={variant} data-testid="CollectionCarousel">
         <ContentContainer maxWidth={itemsWidth} disableGutters>
           <CarouselContainer navigation pagination={{ clickable: true }} loop {...config}>
             {itemsWithVariant.map((item, idx) => (
-              <SwiperSlide key={idx}>
-                <CarouselItem>
-                  <ContentModule {...item} />
-                </CarouselItem>
-              </SwiperSlide>
+              <CarouselSlideRoot key={idx}>
+                <CarouselSlide>
+                  <CarouselContent {...item} sx={undefined} />
+                </CarouselSlide>
+              </CarouselSlideRoot>
             ))}
           </CarouselContainer>
         </ContentContainer>
@@ -83,11 +83,18 @@ const CarouselContainer = styled(Swiper, {
   }
 }));
 
-const CarouselItem = styled(Box, {
+const CarouselSlideRoot = styled(SwiperSlide, {
   name: 'CollectionCarousel',
-  slot: 'CarouselItem',
+  slot: 'SlideRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.carouselItem]
+  overridesResolver: (_, styles) => [styles.slideRoot]
+})``;
+
+const CarouselSlide = styled(Box, {
+  name: 'CollectionCarousel',
+  slot: 'Slide',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.slide]
 })<{ variant?: string }>(() => ({
   display: 'flex',
   justifyContent: 'center',
@@ -95,5 +102,11 @@ const CarouselItem = styled(Box, {
   height: '100%',
   width: '100%'
 }));
+
+const CarouselContent = styled(ContentModule, {
+  name: 'CollectionCarousel',
+  slot: 'Content',
+  overridesResolver: (_, styles) => [styles.content]
+})``;
 
 export default CollectionCarousel;

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.tsx
@@ -56,6 +56,7 @@ const Root = styled(Box, {
 const ContentContainer = styled(Container, {
   name: 'CollectionCarousel',
   slot: 'ContentContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.contentContainer]
 })<{ variant?: string }>(() => ({
   display: 'flex'
@@ -64,6 +65,7 @@ const ContentContainer = styled(Container, {
 const CarouselContainer = styled(Swiper, {
   name: 'CollectionCarousel',
   slot: 'CarouselContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.carouselContainer]
 })<{ variant?: string }>(({ theme }) => ({
   '--swiper-theme-color': theme.palette.primary.main,
@@ -84,6 +86,7 @@ const CarouselContainer = styled(Swiper, {
 const CarouselItem = styled(Box, {
   name: 'CollectionCarousel',
   slot: 'CarouselItem',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.carouselItem]
 })<{ variant?: string }>(() => ({
   display: 'flex',

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.types.ts
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.types.ts
@@ -24,9 +24,9 @@ export interface CollectionCarouselClasses {
   /** Styles applied each Slide(SwiperSlide) Root element. */
   slideRoot: string;
   /** Styles applied each Slide Box element. */
-  slide: string;
+  item: string;
   /** Styles applied to the CarouselContent ContentModule element. */
-  content: string;
+  contentModule: string;
 }
 
 export declare type CollectionCarouselClassKey = keyof CollectionCarouselClasses;

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.types.ts
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.types.ts
@@ -15,14 +15,18 @@ export interface CollectionCarouselProps {
 }
 
 export interface CollectionCarouselClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the root for the CollectionCarousel element. */
   root: string;
-  /** Styles applied to the contentContainer element. */
+  /** Styles applied to the ContentContainer for the CollectionCarousel element. */
   contentContainer: string;
-  /** Styles applied to the carouselContainer element. */
+  /** Styles applied to the CarouselContent (Swiper) for the CollectionCarousel element. */
   carouselContainer: string;
-  /** Styles applied to every carouselItem element. */
-  carouselItem: string;
+  /** Styles applied each Slide(SwiperSlide) Root for the CollectionCarousel element. */
+  slideRoot: string;
+  /** Styles applied each Slide Box for the CollectionCarousel element. */
+  slide: string;
+  /** Styles applied to the CarouselContent ContentModule for the CollectionCarousel element. */
+  content: string;
 }
 
 export declare type CollectionCarouselClassKey = keyof CollectionCarouselClasses;

--- a/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.types.ts
+++ b/packages/component-library/src/components/CollectionCarousel/CollectionCarousel.types.ts
@@ -15,20 +15,20 @@ export interface CollectionCarouselProps {
 }
 
 export interface CollectionCarouselClasses {
-  /** Styles applied to the root for the CollectionCarousel element. */
+  /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the ContentContainer for the CollectionCarousel element. */
+  /** Styles applied to the ContentContainer element. */
   contentContainer: string;
-  /** Styles applied to the CarouselContent (Swiper) for the CollectionCarousel element. */
+  /** Styles applied to the CarouselContent (Swiper) element. */
   carouselContainer: string;
-  /** Styles applied each Slide(SwiperSlide) Root for the CollectionCarousel element. */
+  /** Styles applied each Slide(SwiperSlide) Root element. */
   slideRoot: string;
-  /** Styles applied each Slide Box for the CollectionCarousel element. */
+  /** Styles applied each Slide Box element. */
   slide: string;
-  /** Styles applied to the CarouselContent ContentModule for the CollectionCarousel element. */
+  /** Styles applied to the CarouselContent ContentModule element. */
   content: string;
 }
 
 export declare type CollectionCarouselClassKey = keyof CollectionCarouselClasses;
-declare const accordionClasses: CollectionCarouselClasses;
-export default accordionClasses;
+declare const collectionCarouselClasses: CollectionCarouselClasses;
+export default collectionCarouselClasses;

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.spec.tsx
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.spec.tsx
@@ -39,7 +39,7 @@ describe('CollectionFiltered', () => {
       };
       mockedContent.items = undefined;
       swrMount(<CollectionFiltered {...mockedContent} />);
-      cy.get('[data-testid=CollectionFiltered-TryAgainButton]').should('have.text', 'TRY AGAIN');
+      cy.get('[data-testid=CollectionFiltered-ErrorButton]').should('have.text', 'TRY AGAIN');
     });
 
     it('loads more items when load more button is clicked', () => {

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
@@ -74,6 +74,7 @@ export const CollectionFiltered = ({
       revalidateOnFocus: false
     }
   );
+  // todo: ask if we really want this logs here
   console.log('data => ', data);
   const options = data?.length ? data[0]?.options : defaultOptions;
   console.log('options => ', options);
@@ -109,13 +110,14 @@ export const CollectionFiltered = ({
     .filter((x) => !!x)
     .join(', ');
 
+  //todo: figure out if we still need this log
   console.log('itemsWithVariant => ', { itemsWithVariant, error });
   return (
     <ErrorBoundary>
       <Root {...sidekick(sidekickLookup)} variant={variant} data-testid="CollectionFiltered">
         <ContentContainer maxWidth={itemsWidth}>
-          <Grid container spacing={itemsSpacing ?? 0} sx={{ flexDirection: 'column', alignItems: 'center' }}>
-            <Grid item container sx={{ justifyContent: 'flex-end' }}>
+          <ContainerGrid container spacing={itemsSpacing ?? 0} sx={{ flexDirection: 'column', alignItems: 'center' }}>
+            <CollectionFiltersGrid item container sx={{ justifyContent: 'flex-end' }}>
               <CollectionFilters
                 id={id}
                 filters={filters}
@@ -125,30 +127,33 @@ export const CollectionFiltered = ({
                 filter={filter}
                 onClearFilter={onClearFilter}
               />
-            </Grid>
+            </CollectionFiltersGrid>
             {!itemsWithVariant?.length && !isEmpty(filter) && !loading ? (
-              <Grid item>
-                <Typography variant="h4" data-testid="CollectionFiltered-NoResultsDisplay">
-                  No results for filter: {parsedFilters ? parsedFilters : <Skeleton width={100} />}
-                </Typography>
-              </Grid>
+              <NoResultsGrid item>
+                <NoResultsText variant="h4" data-testid="CollectionFiltered-NoResultsDisplay">
+                  No results for filter: {parsedFilters ? parsedFilters : <NoResultsSkeleton width={100} />}
+                </NoResultsText>
+              </NoResultsGrid>
             ) : null}
             {!itemsWithVariant?.length && error ? (
-              <Grid item>
-                <Typography variant="h4">Error searching for: {parsedFilters}, try again!</Typography>
-                <Button variant="contained" onClick={() => refetch()} data-testid="CollectionFiltered-TryAgainButton">
+              <TryAgainGrid item>
+                <TryAgainText variant="h4">Error searching for: {parsedFilters}, try again!</TryAgainText>
+                <TryAgainButton
+                  variant="contained"
+                  onClick={() => refetch()}
+                  data-testid="CollectionFiltered-TryAgainButton">
                   {'TRY AGAIN'}
-                </Button>
-              </Grid>
+                </TryAgainButton>
+              </TryAgainGrid>
             ) : null}
             {itemsWithVariant?.length ? (
               <>
-                <Grid item container>
-                  <Grid item xs={12}>
-                    <Typography variant="h4" data-testid="CollectionFiltered-ResultsDisplay">
+                <ResultsGridContainer item container>
+                  <ResultsGrid item xs={12}>
+                    <ResultsText variant="h4" data-testid="CollectionFiltered-ResultsDisplay">
                       {parsedFilters ? `Showing results for: ${parsedFilters}` : 'Showing results for: All'}
-                    </Typography>
-                  </Grid>
+                    </ResultsText>
+                  </ResultsGrid>
                   <Section
                     contents={itemsWithVariant}
                     // background={background}
@@ -156,18 +161,19 @@ export const CollectionFiltered = ({
                     contentSpacing={itemsSpacing ?? 0}
                     testId="CollectionFiltered-ItemsSection"
                   />
-                </Grid>
+                </ResultsGridContainer>
               </>
             ) : null}
             {loading ? (
               <>
-                <Grid item container>
+                <MoreResultsContainerGrid item container>
                   {isLoadingMore && (itemsWithVariant?.length ?? 0) < limit ? (
-                    <Grid item xs={12}>
-                      <Typography variant="h4" data-testid="CollectionFiltered-LoadingResultsDisplay">
-                        Showing results for: {parsedFilters ? parsedFilters : <Skeleton width={100} data-testid="" />}
-                      </Typography>
-                    </Grid>
+                    <MoreResultsGrid item xs={12}>
+                      <MoreResultsText variant="h4" data-testid="CollectionFiltered-LoadingResultsDisplay">
+                        Showing results for:{' '}
+                        {parsedFilters ? parsedFilters : <MoreResultsSkeleton width={100} data-testid="" />}
+                      </MoreResultsText>
+                    </MoreResultsGrid>
                   ) : null}
                   <Section
                     contents={range(limit).map((_: any, idx: number) => ({
@@ -180,30 +186,31 @@ export const CollectionFiltered = ({
                     contentSpacing={itemsSpacing ?? 0}
                     testId="CollectionFiltered-LoadingItemsSection"
                   />
-                </Grid>
+                </MoreResultsContainerGrid>
               </>
             ) : null}
             {!isReachingEnd ? (
-              <Grid item sx={{ padding: 2 }}>
-                <Button
+              <ReachingEndGrid item sx={{ padding: 2 }}>
+                <ReachingEndButton
                   variant="contained"
                   onClick={() => setSize(size + 1)}
                   data-testid="CollectionFiltered-LoadMoreButton">
                   {loadMoreText ?? 'LOAD MORE'}
-                </Button>
-              </Grid>
+                </ReachingEndButton>
+              </ReachingEndGrid>
             ) : null}
-          </Grid>
+          </ContainerGrid>
         </ContentContainer>
       </Root>
     </ErrorBoundary>
   );
 };
+const shouldForwardProp = (prop: string) => prop !== 'variant';
 
 const Root = styled(Box, {
   name: 'CollectionFiltered',
   slot: 'Root',
-  shouldForwardProp: (prop) => prop !== 'variant',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root]
 })<{ variant?: string }>(() => ({
   display: 'flex',
@@ -213,10 +220,132 @@ const Root = styled(Box, {
 const ContentContainer = styled(Container, {
   name: 'CollectionFiltered',
   slot: 'ContentContainer',
-  shouldForwardProp: (prop) => prop !== 'variant',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.contentContainer]
 })<{ variant?: string }>(() => ({
   display: 'flex'
 }));
+
+const ContainerGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'ContainerGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.containerGrid]
+})``;
+
+const CollectionFiltersGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'CollectionFiltersGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.collectionFiltersGrid]
+})``;
+
+const NoResultsGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'NoResultsGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.noResultsGrid]
+})``;
+
+const TryAgainGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'TryAgainGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.tryAgainGrid]
+})``;
+
+const ResultsGridContainer = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'ResultsGridContainer',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.resultsGridContainer]
+})``;
+
+const ResultsGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'ResultsGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.resultsGrid]
+})``;
+
+//is it OK to add shouldForwardProp, if this means passing no variant(?)
+// should this be removed from the styled component?
+const NoResultsText = styled(Typography, {
+  name: 'CollectionFiltered',
+  slot: 'NoResultsText',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.noResultsText]
+})``;
+
+const TryAgainText = styled(Typography, {
+  name: 'CollectionFiltered',
+  slot: 'TryAgainText',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.tryAgainText]
+})``;
+
+const ResultsText = styled(Typography, {
+  name: 'CollectionFiltered',
+  slot: 'ResultsText',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.resultsText]
+})``;
+
+const MoreResultsText = styled(Typography, {
+  name: 'CollectionFiltered',
+  slot: 'MoreResultsText',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.moreResultsText]
+})``;
+
+const NoResultsSkeleton = styled(Skeleton, {
+  name: 'CollectionFiltered',
+  slot: 'NoResultsSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.noResultsSkeleton]
+})``;
+
+const MoreResultsSkeleton = styled(Skeleton, {
+  name: 'CollectionFiltered',
+  slot: 'MoreResultsSkeleton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.moreResultsSkeleton]
+})``;
+
+// same question as above
+const ReachingEndButton = styled(Button, {
+  name: 'CollectionFiltered',
+  slot: 'ReachingEndButton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.reachingEndButton]
+})``;
+
+const TryAgainButton = styled(Button, {
+  name: 'CollectionFiltered',
+  slot: 'TryAgainButton',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.tryAgainButton]
+})``;
+
+const MoreResultsContainerGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'MoreResultsContainerGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.moreResultsContainerGrid]
+})``;
+
+const MoreResultsGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'MoreResultsGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.moreResultsGrid]
+})``;
+
+const ReachingEndGrid = styled(Grid, {
+  name: 'CollectionFiltered',
+  slot: 'ReachingEndGrid',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.reachingEndGrid]
+})``;
 
 export default CollectionFiltered;

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
@@ -74,10 +74,8 @@ export const CollectionFiltered = ({
       revalidateOnFocus: false
     }
   );
-  // todo: ask if we really want this logs here
-  console.log('data => ', data);
+
   const options = data?.length ? data[0]?.options : defaultOptions;
-  console.log('options => ', options);
   const items = data?.reduce((accum: CardProps[], page: any) => [...accum, ...(page?.items || [])], []) ?? defaultItems;
   const isLoadingInitialData = !data && !error;
   const isLoadingMore = isLoadingInitialData || (size > 0 && data && typeof data[size - 1] === 'undefined');
@@ -110,14 +108,12 @@ export const CollectionFiltered = ({
     .filter((x) => !!x)
     .join(', ');
 
-  //todo: figure out if we still need this log
-  console.log('itemsWithVariant => ', { itemsWithVariant, error });
   return (
     <ErrorBoundary>
       <Root {...sidekick(sidekickLookup)} variant={variant} data-testid="CollectionFiltered">
-        <ContentContainer maxWidth={itemsWidth}>
-          <ContainerGrid container spacing={itemsSpacing ?? 0} sx={{ flexDirection: 'column', alignItems: 'center' }}>
-            <CollectionFiltersGrid item container sx={{ justifyContent: 'flex-end' }}>
+        <ContentRoot maxWidth={itemsWidth}>
+          <Content container spacing={itemsSpacing ?? 0} sx={{ flexDirection: 'column', alignItems: 'center' }}>
+            <CollectionFilteredRoot item container sx={{ justifyContent: 'flex-end' }}>
               <CollectionFilters
                 id={id}
                 filters={filters}
@@ -127,33 +123,30 @@ export const CollectionFiltered = ({
                 filter={filter}
                 onClearFilter={onClearFilter}
               />
-            </CollectionFiltersGrid>
+            </CollectionFilteredRoot>
             {!itemsWithVariant?.length && !isEmpty(filter) && !loading ? (
-              <NoResultsGrid item>
+              <NoResultsRoot item>
                 <NoResultsText variant="h4" data-testid="CollectionFiltered-NoResultsDisplay">
                   No results for filter: {parsedFilters ? parsedFilters : <NoResultsSkeleton width={100} />}
                 </NoResultsText>
-              </NoResultsGrid>
+              </NoResultsRoot>
             ) : null}
             {!itemsWithVariant?.length && error ? (
-              <TryAgainGrid item>
-                <TryAgainText variant="h4">Error searching for: {parsedFilters}, try again!</TryAgainText>
-                <TryAgainButton
-                  variant="contained"
-                  onClick={() => refetch()}
-                  data-testid="CollectionFiltered-TryAgainButton">
+              <ErrorRoot item>
+                <ErrorMessage variant="h4">Error searching for: {parsedFilters}, try again!</ErrorMessage>
+                <ErrorButton variant="contained" onClick={() => refetch()} data-testid="CollectionFiltered-ErrorButton">
                   {'TRY AGAIN'}
-                </TryAgainButton>
-              </TryAgainGrid>
+                </ErrorButton>
+              </ErrorRoot>
             ) : null}
             {itemsWithVariant?.length ? (
               <>
-                <ResultsGridContainer item container>
-                  <ResultsGrid item xs={12}>
+                <ResultsRoot item container>
+                  <Results item xs={12}>
                     <ResultsText variant="h4" data-testid="CollectionFiltered-ResultsDisplay">
                       {parsedFilters ? `Showing results for: ${parsedFilters}` : 'Showing results for: All'}
                     </ResultsText>
-                  </ResultsGrid>
+                  </Results>
                   <Section
                     contents={itemsWithVariant}
                     // background={background}
@@ -161,19 +154,19 @@ export const CollectionFiltered = ({
                     contentSpacing={itemsSpacing ?? 0}
                     testId="CollectionFiltered-ItemsSection"
                   />
-                </ResultsGridContainer>
+                </ResultsRoot>
               </>
             ) : null}
             {loading ? (
               <>
-                <MoreResultsContainerGrid item container>
+                <LoadingResultsRoot item container>
                   {isLoadingMore && (itemsWithVariant?.length ?? 0) < limit ? (
-                    <MoreResultsGrid item xs={12}>
-                      <MoreResultsText variant="h4" data-testid="CollectionFiltered-LoadingResultsDisplay">
+                    <LoadingResults item xs={12}>
+                      <LoadingResultsText variant="h4" data-testid="CollectionFiltered-LoadingResultsDisplay">
                         Showing results for:{' '}
-                        {parsedFilters ? parsedFilters : <MoreResultsSkeleton width={100} data-testid="" />}
-                      </MoreResultsText>
-                    </MoreResultsGrid>
+                        {parsedFilters ? parsedFilters : <LoadingResultsSkeleton width={100} data-testid="" />}
+                      </LoadingResultsText>
+                    </LoadingResults>
                   ) : null}
                   <Section
                     contents={range(limit).map((_: any, idx: number) => ({
@@ -186,21 +179,21 @@ export const CollectionFiltered = ({
                     contentSpacing={itemsSpacing ?? 0}
                     testId="CollectionFiltered-LoadingItemsSection"
                   />
-                </MoreResultsContainerGrid>
+                </LoadingResultsRoot>
               </>
             ) : null}
             {!isReachingEnd ? (
-              <ReachingEndGrid item sx={{ padding: 2 }}>
-                <ReachingEndButton
+              <LoadMoreRoot item sx={{ padding: 2 }}>
+                <LoadMoreButton
                   variant="contained"
                   onClick={() => setSize(size + 1)}
                   data-testid="CollectionFiltered-LoadMoreButton">
                   {loadMoreText ?? 'LOAD MORE'}
-                </ReachingEndButton>
-              </ReachingEndGrid>
+                </LoadMoreButton>
+              </LoadMoreRoot>
             ) : null}
-          </ContainerGrid>
-        </ContentContainer>
+          </Content>
+        </ContentRoot>
       </Root>
     </ErrorBoundary>
   );
@@ -217,85 +210,79 @@ const Root = styled(Box, {
   justifyContent: 'center'
 }));
 
-const ContentContainer = styled(Container, {
+const ContentRoot = styled(Container, {
   name: 'CollectionFiltered',
-  slot: 'ContentContainer',
+  slot: 'ContentRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.contentContainer]
+  overridesResolver: (_, styles) => [styles.contentRoot]
 })<{ variant?: string }>(() => ({
   display: 'flex'
 }));
 
-const ContainerGrid = styled(Grid, {
+const Content = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'ContainerGrid',
+  slot: 'Content',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.containerGrid]
+  overridesResolver: (_, styles) => [styles.content]
 })``;
 
-const CollectionFiltersGrid = styled(Grid, {
+const CollectionFilteredRoot = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'CollectionFiltersGrid',
+  slot: 'FiltersRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.collectionFiltersGrid]
+  overridesResolver: (_, styles) => [styles.filtersRoot]
 })``;
 
-const NoResultsGrid = styled(Grid, {
+const NoResultsRoot = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'NoResultsGrid',
+  slot: 'NoResultsRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.noResultsGrid]
+  overridesResolver: (_, styles) => [styles.noResultsRoot]
 })``;
 
-const TryAgainGrid = styled(Grid, {
+const ErrorRoot = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'TryAgainGrid',
+  slot: 'ErrorRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.tryAgainGrid]
+  overridesResolver: (_, styles) => [styles.errorRoot]
 })``;
 
-const ResultsGridContainer = styled(Grid, {
+const ResultsRoot = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'ResultsGridContainer',
+  slot: 'ResultsRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.resultsGridContainer]
+  overridesResolver: (_, styles) => [styles.resultsRoot]
 })``;
 
-const ResultsGrid = styled(Grid, {
+const Results = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'ResultsGrid',
+  slot: 'Results',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.resultsGrid]
+  overridesResolver: (_, styles) => [styles.results]
 })``;
 
-//is it OK to add shouldForwardProp, if this means passing no variant(?)
-// should this be removed from the styled component?
 const NoResultsText = styled(Typography, {
   name: 'CollectionFiltered',
   slot: 'NoResultsText',
-  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.noResultsText]
 })``;
 
-const TryAgainText = styled(Typography, {
+const ErrorMessage = styled(Typography, {
   name: 'CollectionFiltered',
-  slot: 'TryAgainText',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.tryAgainText]
+  slot: 'ErrorMessage',
+  overridesResolver: (_, styles) => [styles.errorMessage]
 })``;
 
 const ResultsText = styled(Typography, {
   name: 'CollectionFiltered',
   slot: 'ResultsText',
-  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.resultsText]
 })``;
 
-const MoreResultsText = styled(Typography, {
+const LoadingResultsText = styled(Typography, {
   name: 'CollectionFiltered',
-  slot: 'MoreResultsText',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.moreResultsText]
+  slot: 'LoadingResultsText',
+  overridesResolver: (_, styles) => [styles.loadingResultsText]
 })``;
 
 const NoResultsSkeleton = styled(Skeleton, {
@@ -305,47 +292,44 @@ const NoResultsSkeleton = styled(Skeleton, {
   overridesResolver: (_, styles) => [styles.noResultsSkeleton]
 })``;
 
-const MoreResultsSkeleton = styled(Skeleton, {
+const LoadingResultsSkeleton = styled(Skeleton, {
   name: 'CollectionFiltered',
-  slot: 'MoreResultsSkeleton',
+  slot: 'LoadingResultsSkeleton',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.moreResultsSkeleton]
+  overridesResolver: (_, styles) => [styles.loadingResultsSkeleton]
 })``;
 
-// same question as above
-const ReachingEndButton = styled(Button, {
+const LoadMoreButton = styled(Button, {
   name: 'CollectionFiltered',
-  slot: 'ReachingEndButton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.reachingEndButton]
+  slot: 'LoadMoreButton',
+  overridesResolver: (_, styles) => [styles.loadMoreButton]
 })``;
 
-const TryAgainButton = styled(Button, {
+const ErrorButton = styled(Button, {
   name: 'CollectionFiltered',
-  slot: 'TryAgainButton',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.tryAgainButton]
+  slot: 'ErrorButton',
+  overridesResolver: (_, styles) => [styles.errorButton]
 })``;
 
-const MoreResultsContainerGrid = styled(Grid, {
+const LoadingResultsRoot = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'MoreResultsContainerGrid',
+  slot: 'LoadingResultsRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.moreResultsContainerGrid]
+  overridesResolver: (_, styles) => [styles.loadingResultsRoot]
 })``;
 
-const MoreResultsGrid = styled(Grid, {
+const LoadingResults = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'MoreResultsGrid',
+  slot: 'LoadingResults',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.moreResultsGrid]
+  overridesResolver: (_, styles) => [styles.loadingResults]
 })``;
 
-const ReachingEndGrid = styled(Grid, {
+const LoadMoreRoot = styled(Grid, {
   name: 'CollectionFiltered',
-  slot: 'ReachingEndGrid',
+  slot: 'LoadMoreRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.reachingEndGrid]
+  overridesResolver: (_, styles) => [styles.loadMoreRoot]
 })``;
 
 export default CollectionFiltered;

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
@@ -111,7 +111,7 @@ export const CollectionFiltered = ({
   return (
     <ErrorBoundary>
       <Root {...sidekick(sidekickLookup)} variant={variant} data-testid="CollectionFiltered">
-        <ContentRoot maxWidth={itemsWidth}>
+        <ContentContainer maxWidth={itemsWidth}>
           <Content container spacing={itemsSpacing ?? 0} sx={{ flexDirection: 'column', alignItems: 'center' }}>
             <CollectionFilteredRoot item container sx={{ justifyContent: 'flex-end' }}>
               <CollectionFilters
@@ -193,7 +193,7 @@ export const CollectionFiltered = ({
               </LoadMoreRoot>
             ) : null}
           </Content>
-        </ContentRoot>
+        </ContentContainer>
       </Root>
     </ErrorBoundary>
   );
@@ -210,11 +210,11 @@ const Root = styled(Box, {
   justifyContent: 'center'
 }));
 
-const ContentRoot = styled(Container, {
+const ContentContainer = styled(Container, {
   name: 'CollectionFiltered',
-  slot: 'ContentRoot',
+  slot: 'ContentContainer',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.contentRoot]
+  overridesResolver: (_, styles) => [styles.contentContainer]
 })<{ variant?: string }>(() => ({
   display: 'flex'
 }));

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.tsx
@@ -188,8 +188,7 @@ export const CollectionFiltered = ({
                 <Button
                   variant="contained"
                   onClick={() => setSize(size + 1)}
-                  data-testid="CollectionFiltered-LoadMoreButton"
-                >
+                  data-testid="CollectionFiltered-LoadMoreButton">
                   {loadMoreText ?? 'LOAD MORE'}
                 </Button>
               </Grid>
@@ -214,6 +213,7 @@ const Root = styled(Box, {
 const ContentContainer = styled(Container, {
   name: 'CollectionFiltered',
   slot: 'ContentContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.contentContainer]
 })<{ variant?: string }>(() => ({
   display: 'flex'

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
@@ -54,7 +54,7 @@ export interface CollectionFilteredClasses {
   /** Styles applied to the root element element*/
   root: string;
   /** Styles applied to the ContentRoot element. */
-  contentRoot: string;
+  contentContainer: string;
   /** Styles applied to the Content Grid element. */
   content: string;
   /** Styles applied to the FiltersRoot element. */

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
@@ -51,28 +51,44 @@ export interface CollectionFilteredProps {
 }
 
 export interface CollectionFilteredClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the root element for the CollectionFiltered element*/
   root: string;
-  /** Styles applied to the contentContainer element. */
-  contentContainer: string;
-  // todo: add the rest of the comments
-  containerGrid: string;
-  collectionFiltersGrid: string;
-  noResultsGrid: string;
-  tryAgainGrid: string;
-  resultsGridContainer: string;
-  resultsGrid: string;
+  /** Styles applied to the ContentRoot for the CollectionFiltered element. */
+  contentRoot: string;
+  /** Styles applied to the Content Grid for the CollectionFiltered element. */
+  content: string;
+  /** Styles applied to the FiltersRoot for the CollectionFiltered element. */
+  filtersRoot: string;
+  /** Styles applied to the NoResultsRoot for the CollectionFiltered element. */
+  noResultsRoot: string;
+  /** Styles applied to the ErrorRoot for the CollectionFiltered element. */
+  errorRoot: string;
+  /** Styles applied to the ResultsRoot for the CollectionFiltered element. */
+  resultsRoot: string;
+  /** Styles applied to the Results for the CollectionFiltered element. */
+  results: string;
+  /** Styles applied to the Typography of the NoResults text for the CollectionFiltered element. */
   noResultsText: string;
-  tryAgainText: string;
+  /** Styles applied to the Typography of the ErrorMessage text for the CollectionFiltered element. */
+  errorMessage: string;
+  /** Styles applied to the Typography of the Results text for the CollectionFiltered element. */
   resultsText: string;
-  moreResultsText: string;
+  /** Styles applied to the Typography of the LoadingResults text for the CollectionFiltered element. */
+  loadingResultsText: string;
+  /** Styles applied to the Skeleton of the NoResultsSkeleton text for the CollectionFiltered element. */
   noResultsSkeleton: string;
-  moreResultsSkeleton: string;
-  reachingEndButton: string;
-  tryAgainButton: string;
-  moreResultsContainerGrid: string;
-  moreResultsGrid: string;
-  reachingEndGrid: string;
+  /** Styles applied to the Skeleton of the LoadingResults text for the CollectionFiltered element. */
+  loadingResultsSkeleton: string;
+  /** Styles applied to the LoadMoreButton for the CollectionFiltered element. */
+  loadMoreButton: string;
+  /** Styles applied to the ErrorButton for the CollectionFiltered element. */
+  errorButton: string;
+  /** Styles applied to the LoadingResultsRoot for the CollectionFiltered element. */
+  loadingResultsRoot: string;
+  /** Styles applied to the loadingResults Grid for the CollectionFiltered element. */
+  loadingResults: string;
+  /** Styles applied to the LoadMoreRoot for the CollectionFiltered element. */
+  loadMoreRoot: string;
 }
 
 export declare type CollectionFilteredClassKey = keyof CollectionFilteredClasses;

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
@@ -55,6 +55,24 @@ export interface CollectionFilteredClasses {
   root: string;
   /** Styles applied to the contentContainer element. */
   contentContainer: string;
+  // todo: add the rest of the comments
+  containerGrid: string;
+  collectionFiltersGrid: string;
+  noResultsGrid: string;
+  tryAgainGrid: string;
+  resultsGridContainer: string;
+  resultsGrid: string;
+  noResultsText: string;
+  tryAgainText: string;
+  resultsText: string;
+  moreResultsText: string;
+  noResultsSkeleton: string;
+  moreResultsSkeleton: string;
+  reachingEndButton: string;
+  tryAgainButton: string;
+  moreResultsContainerGrid: string;
+  moreResultsGrid: string;
+  reachingEndGrid: string;
 }
 
 export declare type CollectionFilteredClassKey = keyof CollectionFilteredClasses;

--- a/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
+++ b/packages/component-library/src/components/CollectionFiltered/CollectionFiltered.types.ts
@@ -51,46 +51,46 @@ export interface CollectionFilteredProps {
 }
 
 export interface CollectionFilteredClasses {
-  /** Styles applied to the root element for the CollectionFiltered element*/
+  /** Styles applied to the root element element*/
   root: string;
-  /** Styles applied to the ContentRoot for the CollectionFiltered element. */
+  /** Styles applied to the ContentRoot element. */
   contentRoot: string;
-  /** Styles applied to the Content Grid for the CollectionFiltered element. */
+  /** Styles applied to the Content Grid element. */
   content: string;
-  /** Styles applied to the FiltersRoot for the CollectionFiltered element. */
+  /** Styles applied to the FiltersRoot element. */
   filtersRoot: string;
-  /** Styles applied to the NoResultsRoot for the CollectionFiltered element. */
+  /** Styles applied to the NoResultsRoot element. */
   noResultsRoot: string;
-  /** Styles applied to the ErrorRoot for the CollectionFiltered element. */
+  /** Styles applied to the ErrorRoot element. */
   errorRoot: string;
-  /** Styles applied to the ResultsRoot for the CollectionFiltered element. */
+  /** Styles applied to the ResultsRoot element. */
   resultsRoot: string;
-  /** Styles applied to the Results for the CollectionFiltered element. */
+  /** Styles applied to the Results element. */
   results: string;
-  /** Styles applied to the Typography of the NoResults text for the CollectionFiltered element. */
+  /** Styles applied to the Typography of the NoResults text element. */
   noResultsText: string;
-  /** Styles applied to the Typography of the ErrorMessage text for the CollectionFiltered element. */
+  /** Styles applied to the Typography of the ErrorMessage text element. */
   errorMessage: string;
-  /** Styles applied to the Typography of the Results text for the CollectionFiltered element. */
+  /** Styles applied to the Typography of the Results text element. */
   resultsText: string;
-  /** Styles applied to the Typography of the LoadingResults text for the CollectionFiltered element. */
+  /** Styles applied to the Typography of the LoadingResults text element. */
   loadingResultsText: string;
-  /** Styles applied to the Skeleton of the NoResultsSkeleton text for the CollectionFiltered element. */
+  /** Styles applied to the Skeleton of the NoResultsSkeleton text element. */
   noResultsSkeleton: string;
-  /** Styles applied to the Skeleton of the LoadingResults text for the CollectionFiltered element. */
+  /** Styles applied to the Skeleton of the LoadingResults text element. */
   loadingResultsSkeleton: string;
-  /** Styles applied to the LoadMoreButton for the CollectionFiltered element. */
+  /** Styles applied to the LoadMoreButton element. */
   loadMoreButton: string;
-  /** Styles applied to the ErrorButton for the CollectionFiltered element. */
+  /** Styles applied to the ErrorButton element. */
   errorButton: string;
-  /** Styles applied to the LoadingResultsRoot for the CollectionFiltered element. */
+  /** Styles applied to the LoadingResultsRoot element. */
   loadingResultsRoot: string;
-  /** Styles applied to the loadingResults Grid for the CollectionFiltered element. */
+  /** Styles applied to the loadingResults Grid element. */
   loadingResults: string;
-  /** Styles applied to the LoadMoreRoot for the CollectionFiltered element. */
+  /** Styles applied to the LoadMoreRoot element. */
   loadMoreRoot: string;
 }
 
 export declare type CollectionFilteredClassKey = keyof CollectionFilteredClasses;
-declare const accordionClasses: CollectionFilteredClasses;
-export default accordionClasses;
+declare const collectionFilteredClasses: CollectionFilteredClasses;
+export default collectionFilteredClasses;

--- a/packages/component-library/src/components/CollectionFilters/CollectionFilters.tsx
+++ b/packages/component-library/src/components/CollectionFilters/CollectionFilters.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { Grid, Chip, MenuItem, TextField, Button } from '@mui/material';
-import Autocomplete from '@mui/material/Autocomplete';
+import {
+  Grid,
+  Chip as MuiChip,
+  MenuItem as MuiMenuItem,
+  TextField as MuiTextField,
+  Button as MuiButton
+} from '@mui/material';
+import MuiAutocomplete from '@mui/material/Autocomplete';
 import styled from '@mui/system/styled';
 import capitalize from 'lodash/capitalize';
 import { CollectionFiltersProps, Option } from './CollectionFilters.types';
 
-const CollectionFilters = ({
+const CollectionFiltersComponent = ({
   id,
   // options,
   allOptions,
@@ -21,7 +27,7 @@ const CollectionFilters = ({
 
   return (
     <CollectionFiltersRoot id={`collection_${id}_filters`} container style={{ justifyContent: 'flex-end' }} {...props}>
-      <Grid item container sx={{ justifyContent: 'flex-end' }} spacing={2}>
+      <CollectionFilters item container sx={{ justifyContent: 'flex-end' }} spacing={2}>
         {filters?.map(({ id, label, type, multiple }) => {
           if (!id) return null;
           let input;
@@ -42,7 +48,7 @@ const CollectionFilters = ({
               break;
             case 'select':
               input = (
-                <TextField
+                <SelectTextField
                   select
                   id={id}
                   name={id}
@@ -52,8 +58,7 @@ const CollectionFilters = ({
                   value={filter[id] ?? ''}
                   SelectProps={{ MenuProps: { disableScrollLock: true } }}
                   onChange={handleChange(id)}
-                  data-testid="CollectionFilters-select"
-                >
+                  data-testid="CollectionFilters-select">
                   {allOptions
                     ? allOptions[id]?.map(({ label, value }) => (
                         <MenuItem key={label} value={value ?? ''}>
@@ -61,7 +66,7 @@ const CollectionFilters = ({
                         </MenuItem>
                       ))
                     : null}
-                </TextField>
+                </SelectTextField>
               );
               break;
             case 'autocomplete':
@@ -89,7 +94,7 @@ const CollectionFilters = ({
                     ))
                   }
                   renderInput={(params) => (
-                    <TextField
+                    <AutocompleteTextField
                       {...params}
                       label={`Select a ${label || id}`}
                       name={id}
@@ -106,33 +111,101 @@ const CollectionFilters = ({
           }
           if (input)
             return (
-              <Grid key={id} item xs>
+              <InputRoot key={id} item xs>
                 {input}
-              </Grid>
+              </InputRoot>
             );
           return null;
         })}
-      </Grid>
-      <Grid item>
+      </CollectionFilters>
+      <ButtonRoot item>
         <Button
           data-testid="CollectionFilters-clear"
           onClick={() => {
             setFilter({});
             if (onClearFilter) onClearFilter();
-          }}
-        >
+          }}>
           Clear
         </Button>
-      </Grid>
+      </ButtonRoot>
     </CollectionFiltersRoot>
   );
 };
 
 const CollectionFiltersRoot = styled(Grid, {
-  name: 'CollectionFiltered',
+  name: 'CollectionFilters',
   slot: 'FiltersRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.root]
-})<{ variant?: string }>(() => ({}));
+})``;
 
-export default CollectionFilters;
+const CollectionFilters = styled(Grid, {
+  name: 'CollectionFilters',
+  slot: 'Filters',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.filters]
+})``;
+
+const TextField = styled(MuiTextField, {
+  name: 'CollectionFilters',
+  slot: 'TextField',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.textField]
+})``;
+
+const SelectTextField = styled(MuiTextField, {
+  name: 'CollectionFilters',
+  slot: 'SelectTextField',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.selectTextField]
+})``;
+
+const AutocompleteTextField = styled(MuiTextField, {
+  name: 'CollectionFilters',
+  slot: 'AutocompleteTextField',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.autocompleteTextField]
+})``;
+
+const MenuItem = styled(MuiMenuItem, {
+  name: 'CollectionFilters',
+  slot: 'MenuItem',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.menuItem]
+})``;
+
+const Autocomplete = styled(MuiAutocomplete, {
+  name: 'CollectionFilters',
+  slot: 'Autocomplete',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.autocomplete]
+})``;
+
+const Chip = styled(MuiChip, {
+  name: 'CollectionFilters',
+  slot: 'Chip',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.chip]
+})``;
+
+const InputRoot = styled(Grid, {
+  name: 'CollectionFilters',
+  slot: 'InputRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.inputRoot]
+})``;
+
+const ButtonRoot = styled(Grid, {
+  name: 'CollectionFilters',
+  slot: 'ButtonRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.buttonRoot]
+})``;
+
+const Button = styled(MuiButton, {
+  name: 'CollectionFilters',
+  slot: 'Button',
+  overridesResolver: (_, styles) => [styles.button]
+})``;
+
+export default CollectionFiltersComponent;

--- a/packages/component-library/src/components/CollectionFilters/CollectionFilters.types.ts
+++ b/packages/component-library/src/components/CollectionFilters/CollectionFilters.types.ts
@@ -53,5 +53,5 @@ export interface CollectionFiltersClasses {
 }
 
 export declare type CollectionFiltersClassKey = keyof CollectionFiltersClasses;
-declare const accordionClasses: CollectionFiltersClasses;
-export default accordionClasses;
+declare const collectionFiltersClasses: CollectionFiltersClasses;
+export default collectionFiltersClasses;

--- a/packages/component-library/src/components/CollectionFilters/CollectionFilters.types.ts
+++ b/packages/component-library/src/components/CollectionFilters/CollectionFilters.types.ts
@@ -30,6 +30,26 @@ export interface FilterFormData {
 export interface CollectionFiltersClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the CollectionFilters element. */
+  filters: string;
+  /** Styles applied to the Textfield element. */
+  textField: string;
+  /** Styles applied to the Select Textfield element. */
+  selectTextField: string;
+  /** Styles applied to the Autocomplete Textfield element. */
+  autocompleteTextField: string;
+  /** Styles applied to the MenuItem from the Autocomplete element. */
+  menuItem: string;
+  /** Styles applied to the Autocomplete element. */
+  autocomplete: string;
+  /** Styles applied to each Chip element. */
+  chip: string;
+  /** Styles applied to the Input Root element. */
+  inputRoot: string;
+  /** Styles applied to the Button Root element. */
+  buttonRoot: string;
+  /** Styles applied to the Button element. */
+  button: string;
 }
 
 export declare type CollectionFiltersClassKey = keyof CollectionFiltersClasses;

--- a/packages/component-library/src/components/ContentModule/ContentModule.types.ts
+++ b/packages/component-library/src/components/ContentModule/ContentModule.types.ts
@@ -16,5 +16,5 @@ export interface ContentModuleClasses {
 }
 
 export declare type ContentModuleClassKey = keyof ContentModuleClasses;
-declare const accordionClasses: ContentModuleClasses;
-export default accordionClasses;
+declare const contentModuleClasses: ContentModuleClasses;
+export default contentModuleClasses;

--- a/packages/component-library/src/components/ContentPreview/ContentPreview.types.ts
+++ b/packages/component-library/src/components/ContentPreview/ContentPreview.types.ts
@@ -16,5 +16,5 @@ export interface ContentPreviewClasses {
 }
 
 export declare type ContentPreviewClassKey = keyof ContentPreviewClasses;
-declare const accordionClasses: ContentPreviewClasses;
-export default accordionClasses;
+declare const contentPreviewClasses: ContentPreviewClasses;
+export default contentPreviewClasses;

--- a/packages/component-library/src/components/ContentThemeProvider/ContentThemeProvider.types.ts
+++ b/packages/component-library/src/components/ContentThemeProvider/ContentThemeProvider.types.ts
@@ -12,5 +12,5 @@ export interface ContentModuleClasses {
 }
 
 export declare type ContentModuleClassKey = keyof ContentModuleClasses;
-declare const accordionClasses: ContentModuleClasses;
-export default accordionClasses;
+declare const contentModuleClasses: ContentModuleClasses;
+export default contentModuleClasses;

--- a/packages/component-library/src/components/ErrorBoundary/ErrorBoundary.types.ts
+++ b/packages/component-library/src/components/ErrorBoundary/ErrorBoundary.types.ts
@@ -10,5 +10,5 @@ export interface ErrorBoundaryClasses {
 }
 
 export declare type ErrorBoundaryClassKey = keyof ErrorBoundaryClasses;
-declare const accordionClasses: ErrorBoundaryClasses;
-export default accordionClasses;
+declare const errorBoundaryClasses: ErrorBoundaryClasses;
+export default errorBoundaryClasses;

--- a/packages/component-library/src/components/FormMarketoEmbed/FormMarketoEmbed.tsx
+++ b/packages/component-library/src/components/FormMarketoEmbed/FormMarketoEmbed.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Script from 'next/script';
+import NextScript from 'next/script';
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { FormMarketoEmbedProps } from './FormMarketoEmbed.types';
@@ -45,7 +45,14 @@ const Root = styled(Box, {
   slot: 'Root',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => styles.root
-})<{ variant?: string }>(() => ({}));
+})``;
+
+const Script = styled(NextScript, {
+  name: 'FormMarketoEmbed',
+  slot: 'Script',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => styles.script
+})``;
 
 const Form = styled('form', {
   name: 'FormMarketoEmbed',
@@ -60,7 +67,6 @@ const Form = styled('form', {
       duration: theme.transitions.duration.shorter
     })
   };
-
   return {
     'width': '100% !important',
     'paddingRight': '10px',

--- a/packages/component-library/src/components/FormMarketoEmbed/FormMarketoEmbed.types.ts
+++ b/packages/component-library/src/components/FormMarketoEmbed/FormMarketoEmbed.types.ts
@@ -11,9 +11,11 @@ export interface FormMarketoEmbedProps {
 }
 
 export interface FormMarketoEmbedClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the Root element. */
   root: string;
-  /** Styles applied to the form element. */
+  /** Styles applied to the Script element. */
+  script: string;
+  /** Styles applied to the Form element. */
   form: string;
 }
 

--- a/packages/component-library/src/components/FormMarketoEmbed/FormMarketoEmbed.types.ts
+++ b/packages/component-library/src/components/FormMarketoEmbed/FormMarketoEmbed.types.ts
@@ -20,5 +20,5 @@ export interface FormMarketoEmbedClasses {
 }
 
 export declare type FormMarketoEmbedClassKey = keyof FormMarketoEmbedClasses;
-declare const accordionClasses: FormMarketoEmbedClasses;
-export default accordionClasses;
+declare const formMarketoEmbedClasses: FormMarketoEmbedClasses;
+export default formMarketoEmbedClasses;

--- a/packages/component-library/src/components/Header/Header.tsx
+++ b/packages/component-library/src/components/Header/Header.tsx
@@ -4,8 +4,8 @@ import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Link from '@mui/material/Link';
 import MuiIconButton from '@mui/material/IconButton';
-import MenuIcon from '@mui/icons-material/Menu';
-import CloseIcon from '@mui/icons-material/Close';
+import MuiMenuIcon from '@mui/icons-material/Menu';
+import MuiCloseIcon from '@mui/icons-material/Close';
 import MuiHidden from '@mui/material/Hidden';
 import styled from '@mui/system/styled';
 import { useTheme } from '@mui/system';
@@ -204,7 +204,22 @@ const Hidden = styled(MuiHidden, {
 const IconButton = styled(MuiIconButton, {
   name: 'Header',
   slot: 'IconButton',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.iconButton]
+})``;
+
+const CloseIcon = styled(MuiCloseIcon, {
+  name: 'Header',
+  slot: 'CloseIcon',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.closeIcon]
+})``;
+
+const MenuIcon = styled(MuiMenuIcon, {
+  name: 'Header',
+  slot: 'MenuIcon',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.menuIcon]
 })``;
 
 export default Header;

--- a/packages/component-library/src/components/Header/Header.tsx
+++ b/packages/component-library/src/components/Header/Header.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { Fragment as ReactFragment } from 'react';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Link from '@mui/material/Link';
-import IconButton from '@mui/material/IconButton';
+import MuiIconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import CloseIcon from '@mui/icons-material/Close';
-import Hidden from '@mui/material/Hidden';
+import MuiHidden from '@mui/material/Hidden';
 import styled from '@mui/system/styled';
 import { useTheme } from '@mui/system';
 
@@ -43,29 +43,27 @@ export const Header = (inProps: HeaderProps) => {
           elevation={trigger ? 4 : 0}
           menuVisible={menuVisible}
           menuBreakpoint={menuBreakpoint}
-          {...props}
-        >
+          {...props}>
           <ContentContainer>
             {logo ? (
               <LogoRoot
                 href={logoUrl}
                 sx={{ height: '100%', py: 3 }}
                 {...sidekick(sidekickLookup?.logo)}
-                aria-label={'Go to homepage'}
-              >
+                aria-label={'Go to homepage'}>
                 <Logo {...logo} priority alt={logo?.title ?? 'Go to homepage'} />
               </LogoRoot>
             ) : null}
             {navigationItems?.map((collection) => (
-              <React.Fragment key={collection.id}>
+              <Fragment key={collection.id}>
                 <NavigationDivider />
-                <ContentModule
+                <NavigationBar
                   {...collection}
                   variant={'navigation-bar'}
                   onRequestClose={handleClose}
                   color={props?.color}
                 />
-              </React.Fragment>
+              </Fragment>
             ))}
             <Hidden implementation="css" {...{ [`${menuBreakpoint}Up`]: true }}>
               <IconButton
@@ -73,8 +71,7 @@ export const Header = (inProps: HeaderProps) => {
                 color="inherit"
                 aria-label="menu"
                 onClick={() => setMenuVisible(!menuVisible)}
-                size="large"
-              >
+                size="large">
                 {menuVisible ? <CloseIcon /> : <MenuIcon />}
               </IconButton>
             </Hidden>
@@ -158,6 +155,15 @@ const Root = styled(AppBar, {
     `}
 `;
 
+const ContentContainer = styled(Toolbar, {
+  name: 'Header',
+  slot: 'ContentContainer',
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.contentContainer]
+})<{ variant?: string }>`
+  height: 100%;
+`;
+
 const LogoRoot = styled(Link, {
   name: 'Header',
   slot: 'LogoRoot',
@@ -168,7 +174,6 @@ const LogoRoot = styled(Link, {
 const Logo = styled(ContentModule, {
   name: 'Header',
   slot: 'Logo',
-  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.logo]
 })<{ variant?: string }>(() => ({
   height: '100%',
@@ -184,13 +189,29 @@ const NavigationDivider = styled(Box, {
   flex-grow: 1;
 `;
 
-const ContentContainer = styled(Toolbar, {
+const NavigationBar = styled(ContentModule, {
   name: 'Header',
-  slot: 'ContentContainer',
+  slot: 'NavigationBar',
+  overridesResolver: (_, styles) => [styles.navigationBar]
+})``;
+
+const Fragment = styled(ReactFragment, {
+  name: 'Header',
+  slot: 'Fragment',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.contentContainer]
-})<{ variant?: string }>`
-  height: 100%;
-`;
+  overridesResolver: (_, styles) => [styles.fragment]
+})``;
+
+const Hidden = styled(MuiHidden, {
+  name: 'Header',
+  slot: 'Hidden',
+  overridesResolver: (_, styles) => [styles.hidden]
+})``;
+
+const IconButton = styled(MuiIconButton, {
+  name: 'Header',
+  slot: 'IconButton',
+  overridesResolver: (_, styles) => [styles.iconButton]
+})``;
 
 export default Header;

--- a/packages/component-library/src/components/Header/Header.tsx
+++ b/packages/component-library/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment as ReactFragment } from 'react';
+import React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
@@ -12,7 +12,7 @@ import { useTheme } from '@mui/system';
 
 import ErrorBoundary from '../ErrorBoundary';
 
-import ContentModule from '../ContentModule';
+import CModule from '../ContentModule';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
 import sidekick from '@last-rev/contentful-sidekick-util';
 import { HeaderProps } from './Header.types';
@@ -55,15 +55,15 @@ export const Header = (inProps: HeaderProps) => {
               </LogoRoot>
             ) : null}
             {navigationItems?.map((collection) => (
-              <Fragment key={collection.id}>
+              <React.Fragment key={collection.id}>
                 <NavigationDivider />
-                <NavigationBar
+                <ContentModule
                   {...collection}
                   variant={'navigation-bar'}
                   onRequestClose={handleClose}
                   color={props?.color}
                 />
-              </Fragment>
+              </React.Fragment>
             ))}
             <Hidden implementation="css" {...{ [`${menuBreakpoint}Up`]: true }}>
               <IconButton
@@ -171,7 +171,7 @@ const LogoRoot = styled(Link, {
   overridesResolver: (_, styles) => [styles.logoRoot]
 })(() => ({}));
 
-const Logo = styled(ContentModule, {
+const Logo = styled(CModule, {
   name: 'Header',
   slot: 'Logo',
   overridesResolver: (_, styles) => [styles.logo]
@@ -189,17 +189,10 @@ const NavigationDivider = styled(Box, {
   flex-grow: 1;
 `;
 
-const NavigationBar = styled(ContentModule, {
+const ContentModule = styled(CModule, {
   name: 'Header',
-  slot: 'NavigationBar',
-  overridesResolver: (_, styles) => [styles.navigationBar]
-})``;
-
-const Fragment = styled(ReactFragment, {
-  name: 'Header',
-  slot: 'Fragment',
-  shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.fragment]
+  slot: 'ContentModule',
+  overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 
 const Hidden = styled(MuiHidden, {

--- a/packages/component-library/src/components/Header/Header.types.ts
+++ b/packages/component-library/src/components/Header/Header.types.ts
@@ -12,12 +12,24 @@ export interface HeaderProps {
 }
 
 export interface HeaderClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the Root for the Header element. */
   root: string;
-  /** Styles applied to the form element. */
-  logo: string;
-  /** Styles applied to the contentContainer element. */
+  /** Styles applied to the contentContainer for the Header element. */
   contentContainer: string;
+  /** Styles applied to the Logo Link for the Header element. */
+  logoRoot: string;
+  /** Styles applied to the Logo - Content Module for the Header element. */
+  logo: string;
+  /** Styles applied to the Navigation Divider for the Header element. */
+  navigationDivider: string;
+  /** Styles applied to the Navigation Bar - Content Module for the Header element. */
+  navigationBar: string;
+  /** Styles applied to the Fragment that contains Navigation Divider and Navigation Bar for the Header element. */
+  fragment: string;
+  /** Styles applied to the Hidden for the Header element. */
+  hidden: string;
+  /** Styles applied to the IconButton Icon for the Header element. */
+  iconButton: string;
 }
 
 export declare type HeaderClassKey = keyof HeaderClasses;

--- a/packages/component-library/src/components/Header/Header.types.ts
+++ b/packages/component-library/src/components/Header/Header.types.ts
@@ -30,6 +30,10 @@ export interface HeaderClasses {
   hidden: string;
   /** Styles applied to the IconButton Icon element. */
   iconButton: string;
+  /** Styles applied to the Close Icon element. */
+  closeIcon: string;
+  /** Styles applied to the Menu Icon element. */
+  menuIcon: string;
 }
 
 export declare type HeaderClassKey = keyof HeaderClasses;

--- a/packages/component-library/src/components/Header/Header.types.ts
+++ b/packages/component-library/src/components/Header/Header.types.ts
@@ -22,8 +22,8 @@ export interface HeaderClasses {
   logo: string;
   /** Styles applied to the Navigation Divider element. */
   navigationDivider: string;
-  /** Styles applied to the Navigation Bar - Content Module element. */
-  navigationBar: string;
+  /** Styles applied to the Content Module - Navigation Bar element. */
+  contentModule: string;
   /** Styles applied to the Fragment that contains Navigation Divider and Navigation Bar element. */
   fragment: string;
   /** Styles applied to the Hidden element. */

--- a/packages/component-library/src/components/Header/Header.types.ts
+++ b/packages/component-library/src/components/Header/Header.types.ts
@@ -12,26 +12,26 @@ export interface HeaderProps {
 }
 
 export interface HeaderClasses {
-  /** Styles applied to the Root for the Header element. */
+  /** Styles applied to the Root element. */
   root: string;
-  /** Styles applied to the contentContainer for the Header element. */
+  /** Styles applied to the contentContainer element. */
   contentContainer: string;
-  /** Styles applied to the Logo Link for the Header element. */
+  /** Styles applied to the Logo Link element. */
   logoRoot: string;
-  /** Styles applied to the Logo - Content Module for the Header element. */
+  /** Styles applied to the Logo - Content Module element. */
   logo: string;
-  /** Styles applied to the Navigation Divider for the Header element. */
+  /** Styles applied to the Navigation Divider element. */
   navigationDivider: string;
-  /** Styles applied to the Navigation Bar - Content Module for the Header element. */
+  /** Styles applied to the Navigation Bar - Content Module element. */
   navigationBar: string;
-  /** Styles applied to the Fragment that contains Navigation Divider and Navigation Bar for the Header element. */
+  /** Styles applied to the Fragment that contains Navigation Divider and Navigation Bar element. */
   fragment: string;
-  /** Styles applied to the Hidden for the Header element. */
+  /** Styles applied to the Hidden element. */
   hidden: string;
-  /** Styles applied to the IconButton Icon for the Header element. */
+  /** Styles applied to the IconButton Icon element. */
   iconButton: string;
 }
 
 export declare type HeaderClassKey = keyof HeaderClasses;
-declare const accordionClasses: HeaderClasses;
-export default accordionClasses;
+declare const headerClasses: HeaderClasses;
+export default headerClasses;

--- a/packages/component-library/src/components/Hero/Hero.tsx
+++ b/packages/component-library/src/components/Hero/Hero.tsx
@@ -294,8 +294,8 @@ const MediaHero = styled(ContentModule, {
 
 const MediaDivider = styled(ContentModule, {
   name: 'Hero',
-  slot: 'MediaDividerRoot',
-  overridesResolver: (_, styles) => [styles.mediaDividerRoot]
+  slot: 'MediaDivider',
+  overridesResolver: (_, styles) => [styles.mediaDivider]
 })``;
 
 export default Hero;

--- a/packages/component-library/src/components/Hero/Hero.tsx
+++ b/packages/component-library/src/components/Hero/Hero.tsx
@@ -47,8 +47,7 @@ export const Hero = (props: HeroProps) => {
           position: background ? 'relative' : undefined,
           overflow: background ? 'hidden' : undefined,
           py: 4
-        }}
-      >
+        }}>
         {background ? (
           <BackgroundRoot
             sx={{
@@ -58,8 +57,7 @@ export const Hero = (props: HeroProps) => {
               left: 0,
               width: '100%',
               height: '100%'
-            }}
-          >
+            }}>
             <ContentModule
               __typename="Media"
               key={background?.id}
@@ -87,8 +85,7 @@ export const Hero = (props: HeroProps) => {
                       data-testid="Hero-title"
                       variant="h1"
                       component="h1"
-                      {...sidekick(sidekickLookup?.title)}
-                    >
+                      {...sidekick(sidekickLookup?.title)}>
                       {title}
                     </Typography>
                   ) : null}
@@ -97,8 +94,7 @@ export const Hero = (props: HeroProps) => {
                       data-testid="Hero-subtitle"
                       variant={!title ? 'h1' : 'h2'}
                       component={!title ? 'h1' : 'h2'}
-                      {...sidekick(sidekickLookup?.subtitle)}
-                    >
+                      {...sidekick(sidekickLookup?.subtitle)}>
                       {subtitle}
                     </Typography>
                   ) : null}
@@ -229,6 +225,7 @@ const ActionsRoot = styled(Box, {
 const ContentContainer = styled(Container, {
   name: 'Hero',
   slot: 'ContentContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.contentContainer]
 })<{ variant?: string }>(({ theme }) => ({
   zIndex: 1,

--- a/packages/component-library/src/components/Hero/Hero.tsx
+++ b/packages/component-library/src/components/Hero/Hero.tsx
@@ -58,7 +58,7 @@ export const Hero = (props: HeroProps) => {
               width: '100%',
               height: '100%'
             }}>
-            <ContentModule
+            <BackgroundMedia
               __typename="Media"
               key={background?.id}
               testId="Hero-background"
@@ -71,35 +71,33 @@ export const Hero = (props: HeroProps) => {
           </BackgroundRoot>
         ) : null}
         <ContentContainer maxWidth={contentWidth} disableGutters={disableGutters}>
-          <Grid container rowSpacing={5} columnSpacing={variant === 'centered' ? 0 : 5}>
+          <ContentRoot container rowSpacing={5} columnSpacing={variant === 'centered' ? 0 : 5}>
             {title || subtitle || body || actions ? (
-              <Grid item container direction="column" spacing={2} xs={12} md={6}>
-                <Grid item>
+              <TextsContainer item container direction="column" spacing={2} xs={12} md={6}>
+                <TextsRoot item>
                   {overline ? (
-                    <Typography data-testid="Hero-overline" variant="overline" {...sidekick(sidekickLookup?.overline)}>
+                    <OverlineHero
+                      data-testid="Hero-overline"
+                      variant="overline"
+                      {...sidekick(sidekickLookup?.overline)}>
                       {overline}
-                    </Typography>
+                    </OverlineHero>
                   ) : null}
                   {title ? (
-                    <Typography
-                      data-testid="Hero-title"
-                      variant="h1"
-                      component="h1"
-                      {...sidekick(sidekickLookup?.title)}>
+                    <TitleHero data-testid="Hero-title" variant="h1" {...sidekick(sidekickLookup?.title)}>
                       {title}
-                    </Typography>
+                    </TitleHero>
                   ) : null}
                   {subtitle ? (
-                    <Typography
+                    <SubtitleHero
                       data-testid="Hero-subtitle"
                       variant={!title ? 'h1' : 'h2'}
-                      component={!title ? 'h1' : 'h2'}
                       {...sidekick(sidekickLookup?.subtitle)}>
                       {subtitle}
-                    </Typography>
+                    </SubtitleHero>
                   ) : null}
                   {body ? (
-                    <ContentModule
+                    <BodyHero
                       __typename="Text"
                       variant="hero"
                       body={body}
@@ -110,16 +108,16 @@ export const Hero = (props: HeroProps) => {
                   {actions ? (
                     <ActionsRoot pt={title || subtitle || body ? 3 : undefined} {...sidekick(sidekickLookup?.actions)}>
                       {actions?.map((link) => (
-                        <ContentModule key={link.id} {...link} />
+                        <ButtonHero key={link.id} {...link} />
                       ))}
                     </ActionsRoot>
                   ) : null}
-                </Grid>
-              </Grid>
+                </TextsRoot>
+              </TextsContainer>
             ) : null}
             {image ? (
               <MediaRoot item xs={12} md={6}>
-                <ContentModule
+                <MediaHero
                   __typename="Media"
                   key={image?.id}
                   {...image}
@@ -130,7 +128,7 @@ export const Hero = (props: HeroProps) => {
                 />
               </MediaRoot>
             ) : null}
-          </Grid>
+          </ContentRoot>
         </ContentContainer>
         {divider ? (
           <MediaDivider {...divider} {...sidekick(sidekickLookup?.divider)} testId="Hero-divider" priority />
@@ -190,22 +188,6 @@ const Root = styled(Box, {
   alignContent: 'center'
 }));
 
-const MediaRoot = styled(Grid, {
-  name: 'Hero',
-  slot: 'MediaRoot',
-  shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.mediaRoot]
-})`
-  position: relative;
-`;
-
-const MediaDivider = styled(ContentModule, {
-  name: 'Hero',
-  slot: 'MediaDividerRoot',
-  shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.mediaDividerRoot]
-})``;
-
 const BackgroundRoot = styled(Box, {
   name: 'Hero',
   slot: 'BackgroundRoot',
@@ -213,14 +195,11 @@ const BackgroundRoot = styled(Box, {
   overridesResolver: (_, styles) => [styles.backgroundRoot]
 })``;
 
-const ActionsRoot = styled(Box, {
+const BackgroundMedia = styled(ContentModule, {
   name: 'Hero',
-  slot: 'ActionsRoot',
-  shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.actionsRoot]
-})`
-  display: flex;
-`;
+  slot: 'BackgroundMedia',
+  overridesResolver: (_, styles) => [styles.backgroundMedia]
+})``;
 
 const ContentContainer = styled(Container, {
   name: 'Hero',
@@ -237,5 +216,86 @@ const ContentContainer = styled(Container, {
     alignContent: 'center'
   }
 }));
+
+const ContentRoot = styled(Grid, {
+  name: 'Hero',
+  slot: 'ContentRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.contentRoot]
+})``;
+
+const TextsContainer = styled(Grid, {
+  name: 'Hero',
+  slot: 'TextsContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.textsContainer]
+})``;
+
+const TextsRoot = styled(Grid, {
+  name: 'Hero',
+  slot: 'TextsRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.textsRoot]
+})``;
+
+const OverlineHero = styled(Typography, {
+  name: 'Hero',
+  slot: 'OverlineHero',
+  overridesResolver: (_, styles) => [styles.OverlineHero]
+})``;
+
+const TitleHero = styled(Typography, {
+  name: 'Hero',
+  slot: 'TitleHero',
+  overridesResolver: (_, styles) => [styles.titleHero]
+})``;
+
+const SubtitleHero = styled(Typography, {
+  name: 'Hero',
+  slot: 'SubtitleHero',
+  overridesResolver: (_, styles) => [styles.subtitleHero]
+})``;
+
+const BodyHero = styled(ContentModule, {
+  name: 'Hero',
+  slot: 'BodyHero',
+  overridesResolver: (_, styles) => [styles.bodyHero]
+})``;
+
+const ActionsRoot = styled(Box, {
+  name: 'Hero',
+  slot: 'ActionsRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.actionsRoot]
+})`
+  display: flex;
+`;
+
+const ButtonHero = styled(ContentModule, {
+  name: 'Hero',
+  slot: 'ButtonHero',
+  overridesResolver: (_, styles) => [styles.buttonHero]
+})``;
+
+const MediaRoot = styled(Grid, {
+  name: 'Hero',
+  slot: 'MediaRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.mediaRoot]
+})`
+  position: relative;
+`;
+
+const MediaHero = styled(ContentModule, {
+  name: 'Hero',
+  slot: 'MediaHero',
+  overridesResolver: (_, styles) => [styles.mediaHero]
+})``;
+
+const MediaDivider = styled(ContentModule, {
+  name: 'Hero',
+  slot: 'MediaDividerRoot',
+  overridesResolver: (_, styles) => [styles.mediaDividerRoot]
+})``;
 
 export default Hero;

--- a/packages/component-library/src/components/Hero/Hero.tsx
+++ b/packages/component-library/src/components/Hero/Hero.tsx
@@ -241,7 +241,7 @@ const TextsRoot = styled(Grid, {
 const OverlineHero = styled(Typography, {
   name: 'Hero',
   slot: 'OverlineHero',
-  overridesResolver: (_, styles) => [styles.OverlineHero]
+  overridesResolver: (_, styles) => [styles.overlineHero]
 })``;
 
 const TitleHero = styled(Typography, {

--- a/packages/component-library/src/components/Hero/Hero.types.ts
+++ b/packages/component-library/src/components/Hero/Hero.types.ts
@@ -37,23 +37,45 @@ export interface HeroProps {
 }
 
 export interface HeroClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the Root for the Hero element. */
   root: string;
-  /** Styles applied to the mediaRoot element. */
-  mediaRoot: string;
-  /** Styles applied to the backgroundRoot element. */
+  /** Styles applied to the BackgroundRoot for the Hero element. */
   backgroundRoot: string;
-  /** Styles applied to the actionsRoot element. */
-  actionsRoot: string;
-  /** Styles applied to the contentContainer element. */
+  /** Styles applied to the BackgroundMedia ContentModule for the Hero element. */
+  backgroundMedia: string;
+  /** Styles applied to the ContentContainer for the Hero element.. */
   contentContainer: string;
-  /** Styles applied to the root element when contentHeigh is sm. */
+  /** Styles applied to the ContentRoot for the Hero element. */
+  contentRoot: string;
+  /** Styles applied to the TextsContainer for the Hero element. */
+  textsContainer: string;
+  /** Styles applied to the TextsRoot for the Hero element. */
+  textsRoot: string;
+  /** Styles applied to the Typography of the overline text for the Hero element. */
+  overlineHero: string;
+  /** Styles applied to the Typography of the title text the for the Hero element. */
+  titleHero: string;
+  /** Styles applied to the Typography of the subtitle text the for the Hero element. */
+  SubtitleHero: string;
+  /** Styles applied to the Text of the body for the Hero element. */
+  bodyHero: string;
+  /** Styles applied to the ActionsRoot for the Hero element. */
+  actionsRoot: string;
+  /** Styles applied to the ButtonHero for the Hero element. */
+  ButtonHero: string;
+  /** Styles applied to the mediaRoot for the Hero element. */
+  mediaRoot: string;
+  /** Styles applied to the MediaHero ContentModule for the Hero element. */
+  mediaHero: string;
+  /** Styles applied to the MediaDivider for the Hero element. */
+  mediaDivider: string;
+  /** Styles applied to the root element when contentHeigh is sm for the Hero element.*/
   contentHeightSM: string;
-  /** Styles applied to the root element when contentHeigh is md. */
+  /** Styles applied to the root element when contentHeigh is md for the Hero element. */
   contentHeightMD: string;
-  /** Styles applied to the root element when contentHeigh is lg. */
+  /** Styles applied to the root element when contentHeigh is lg for the Hero element. */
   contentHeightLG: string;
-  /** Styles applied to the root element when contentHeigh is xl. */
+  /** Styles applied to the root element when contentHeigh is xl for the Hero element. */
   contentHeightXL: string;
 }
 

--- a/packages/component-library/src/components/Hero/Hero.types.ts
+++ b/packages/component-library/src/components/Hero/Hero.types.ts
@@ -37,48 +37,48 @@ export interface HeroProps {
 }
 
 export interface HeroClasses {
-  /** Styles applied to the Root for the Hero element. */
+  /** Styles applied to the Root element. */
   root: string;
-  /** Styles applied to the BackgroundRoot for the Hero element. */
+  /** Styles applied to the BackgroundRoot element. */
   backgroundRoot: string;
-  /** Styles applied to the BackgroundMedia ContentModule for the Hero element. */
+  /** Styles applied to the BackgroundMedia ContentModule element. */
   backgroundMedia: string;
-  /** Styles applied to the ContentContainer for the Hero element.. */
+  /** Styles applied to the ContentContainer element.. */
   contentContainer: string;
-  /** Styles applied to the ContentRoot for the Hero element. */
+  /** Styles applied to the ContentRoot element. */
   contentRoot: string;
-  /** Styles applied to the TextsContainer for the Hero element. */
+  /** Styles applied to the TextsContainer element. */
   textsContainer: string;
-  /** Styles applied to the TextsRoot for the Hero element. */
+  /** Styles applied to the TextsRoot element. */
   textsRoot: string;
-  /** Styles applied to the Typography of the overline text for the Hero element. */
+  /** Styles applied to the Typography of the overline text element. */
   overlineHero: string;
-  /** Styles applied to the Typography of the title text the for the Hero element. */
+  /** Styles applied to the Typography of the title text the element. */
   titleHero: string;
-  /** Styles applied to the Typography of the subtitle text the for the Hero element. */
-  SubtitleHero: string;
-  /** Styles applied to the Text of the body for the Hero element. */
+  /** Styles applied to the Typography of the subtitle text the element. */
+  subtitleHero: string;
+  /** Styles applied to the Text of the body element. */
   bodyHero: string;
-  /** Styles applied to the ActionsRoot for the Hero element. */
+  /** Styles applied to the ActionsRoot element. */
   actionsRoot: string;
-  /** Styles applied to the ButtonHero for the Hero element. */
-  ButtonHero: string;
-  /** Styles applied to the mediaRoot for the Hero element. */
+  /** Styles applied to the ButtonHero element. */
+  buttonHero: string;
+  /** Styles applied to the mediaRoot element. */
   mediaRoot: string;
-  /** Styles applied to the MediaHero ContentModule for the Hero element. */
+  /** Styles applied to the MediaHero ContentModule element. */
   mediaHero: string;
-  /** Styles applied to the MediaDivider for the Hero element. */
+  /** Styles applied to the MediaDivider element. */
   mediaDivider: string;
-  /** Styles applied to the root element when contentHeigh is sm for the Hero element.*/
+  /** Styles applied to the root element when contentHeigh is sm element.*/
   contentHeightSM: string;
-  /** Styles applied to the root element when contentHeigh is md for the Hero element. */
+  /** Styles applied to the root element when contentHeigh is md element. */
   contentHeightMD: string;
-  /** Styles applied to the root element when contentHeigh is lg for the Hero element. */
+  /** Styles applied to the root element when contentHeigh is lg element. */
   contentHeightLG: string;
-  /** Styles applied to the root element when contentHeigh is xl for the Hero element. */
+  /** Styles applied to the root element when contentHeigh is xl element. */
   contentHeightXL: string;
 }
 
 export declare type HeroClassKey = keyof HeroClasses;
-declare const accordionClasses: HeroClasses;
-export default accordionClasses;
+declare const heroClasses: HeroClasses;
+export default heroClasses;

--- a/packages/component-library/src/components/Image/Image.types.ts
+++ b/packages/component-library/src/components/Image/Image.types.ts
@@ -23,5 +23,5 @@ export interface ImageClasses {
 }
 
 export declare type ImageClassKey = keyof ImageClasses;
-declare const accordionClasses: ImageClasses;
-export default accordionClasses;
+declare const imageClasses: ImageClasses;
+export default imageClasses;

--- a/packages/component-library/src/components/Link/Link.tsx
+++ b/packages/component-library/src/components/Link/Link.tsx
@@ -152,7 +152,6 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
       </RootIconButton>
     );
   }
-
   if (variant?.includes('button-')) {
     const buttonVariant = variant.replace('button-', '') as 'text' | 'outlined' | 'contained' | undefined;
     if (href !== '#') {
@@ -200,7 +199,6 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
       </RootButton>
     );
   }
-
   if (isExternal) {
     if (noLinkStyle) {
       return (
@@ -228,7 +226,6 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
       </RootMuiLink>
     );
   }
-
   if (noLinkStyle && icon) {
     return (
       <NextLinkComposed className={className} ref={ref as any} to={href} {...other}>
@@ -264,6 +261,8 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
     </RootMuiLink>
   );
 });
+
+const shouldForwardProp = (prop: string) => prop !== '__typename';
 
 const Root = styled(Box, {
   name: 'Link',

--- a/packages/component-library/src/components/Link/Link.tsx
+++ b/packages/component-library/src/components/Link/Link.tsx
@@ -44,8 +44,7 @@ export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComp
         scroll={scroll}
         shallow={shallow}
         passHref={passHref}
-        locale={locale}
-      >
+        locale={locale}>
         <RootLink ref={ref} {...other} onClick={onClick}>
           {text || children}
         </RootLink>
@@ -123,8 +122,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
           ref={ref as any}
           target="_blank"
           rel="noopener noreferrer"
-          {...extra}
-        >
+          {...extra}>
           <RootIconButton aria-label={icon} size="large">
             {getIcon(icon)}
           </RootIconButton>
@@ -149,8 +147,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
         // type={other.type}
         // {...extra}
         onClick={other.onClick}
-        size="large"
-      >
+        size="large">
         {getIcon(icon)}
       </RootIconButton>
     );
@@ -168,8 +165,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
               {...extra}
               variant={buttonVariant}
               startIcon={icon && iconPosition === 'Left' && getIcon(icon)}
-              endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}
-            >
+              endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}>
               {text || children}
             </RootButton>
           </RootLink>
@@ -184,8 +180,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
             {...extra}
             variant={buttonVariant}
             startIcon={icon && iconPosition === 'Left' && getIcon(icon)}
-            endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}
-          >
+            endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}>
             {text || children}
           </RootButton>
         </NextLink>
@@ -200,8 +195,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
         {...extra}
         variant={buttonVariant}
         startIcon={icon && iconPosition === 'Left' && getIcon(icon)}
-        endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}
-      >
+        endIcon={icon && iconPosition !== 'Left' && getIcon(icon)}>
         {text || children}
       </RootButton>
     );
@@ -216,8 +210,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
           ref={ref as any}
           target="_blank"
           rel="noopener noreferrer"
-          {...extra}
-        >
+          {...extra}>
           {getButtonContent(text, children, iconPosition, icon)}
         </RootLink>
       );
@@ -230,8 +223,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
         ref={ref}
         target="_blank"
         rel="noopener noreferrer"
-        {...extra}
-      >
+        {...extra}>
         {getButtonContent(text, children, iconPosition, icon)}
       </RootMuiLink>
     );
@@ -267,8 +259,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
       {...extra}
       // Not getting the prop validation from NextLinkComposed
       // @ts-expect-error
-      passHref
-    >
+      passHref>
       {getButtonContent(text, children, iconPosition, icon)}
     </RootMuiLink>
   );
@@ -277,6 +268,7 @@ const Link = React.forwardRef<any, LinkProps>(function Link(props, ref) {
 const Root = styled(Box, {
   name: 'Link',
   slot: 'Root',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root]
 })<{}>(() => ({
   display: 'inline-flex',
@@ -286,24 +278,28 @@ const Root = styled(Box, {
 const RootLink = styled('a', {
   name: 'Link',
   slot: 'Root',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root, styles.rootLink]
 })<{}>(() => ({}));
 
 const RootMuiLink = styled(MuiLink, {
   name: 'Link',
   slot: 'Root',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root, styles.rootMuiLink]
 })``;
 
 const RootButton = styled(Button, {
   name: 'Link',
   slot: 'Root',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root, styles.rootButton]
 })``;
 
 const RootIconButton = styled(IconButton, {
   name: 'Link',
   slot: 'Root',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root, styles.rootButton]
 })``;
 

--- a/packages/component-library/src/components/Link/Link.types.ts
+++ b/packages/component-library/src/components/Link/Link.types.ts
@@ -41,9 +41,15 @@ export type LinkProps = {
 export interface LinkClasses {
   // TODO: Add root styled to Link for every variant
   /** Styles applied to the root element. */
-  // root: string;
+  root: string;
+  /** Styles applied to the Link element. */
+  rootLink: string;
+  /** Styles applied to the MuiLink element. */
+  rootMuiLink: string;
+  /** Styles applied to the Button element. */
+  rootButton: string;
   /** Styles applied to the container element ONLY when icon is selected. */
-  // buttonWrap: string;
+  buttonWrap: string;
 }
 
 export declare type LinkClassKey = keyof LinkClasses;

--- a/packages/component-library/src/components/Link/Link.types.ts
+++ b/packages/component-library/src/components/Link/Link.types.ts
@@ -47,5 +47,5 @@ export interface LinkClasses {
 }
 
 export declare type LinkClassKey = keyof LinkClasses;
-declare const accordionClasses: LinkClasses;
-export default accordionClasses;
+declare const linkClasses: LinkClasses;
+export default linkClasses;

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
@@ -343,7 +343,6 @@ const FormControl = styled(MuiFormControl, {
 const Link = styled(LRFALink, {
   name: 'Form',
   slot: 'Link',
-  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.link]
 })``;
 

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
@@ -6,7 +6,7 @@ import ErrorBoundary from '../ErrorBoundary';
 import LRFALink from '../Link';
 
 import ContentModule from '../ContentModule';
-import MCMailchimpSubscribe from 'react-mailchimp-subscribe';
+import MailchimpSubscribe from 'react-mailchimp-subscribe';
 import snakeCase from 'lodash/snakeCase';
 import sidekick from '@last-rev/contentful-sidekick-util';
 import getFirstOfArray from '../../utils/getFirstOfArray';
@@ -248,13 +248,6 @@ const FormRoot = styled(Grid, {
   slot: 'FormRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.formRoot]
-})``;
-
-const MailchimpSubscribe = styled(MCMailchimpSubscribe, {
-  name: 'MailchimpForm',
-  slot: 'MailchimpSubscribe',
-  shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.mailchimpSubscribe]
 })``;
 
 //Form components

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
@@ -97,7 +97,7 @@ const CustomForm = ({
         <SubmitContainer container item xs={12} sm={4} sx={{ px: 5, zIndex: 1, opacity: status === 'success' ? 0 : 1 }}>
           <FormControl>
             {actions?.map((link) => (
-              <Link key={link.id} {...link} type="submit" disabled={loading} />
+              <LRFALink key={link.id} {...link} type="submit" disabled={loading} />
             ))}
           </FormControl>
         </SubmitContainer>
@@ -169,7 +169,6 @@ export const MailchimpForm = ({
               />
             ) : null}
           </TextsRoot>
-
           <FormRoot container item sx={{ position: 'relative' }}>
             <MailchimpSubscribe
               url={url}
@@ -226,19 +225,19 @@ const TextsRoot = styled(Grid, {
 })``;
 
 const TitleMailChimpForm = styled(Typography, {
-  name: 'Hero',
+  name: 'MailchimpForm',
   slot: 'TitleMailChimpForm',
   overridesResolver: (_, styles) => [styles.titleMailChimpForm]
 })``;
 
 const SubtitleMailChimpForm = styled(Typography, {
-  name: 'Hero',
+  name: 'MailchimpForm',
   slot: 'SubtitleMailChimpForm',
   overridesResolver: (_, styles) => [styles.subtitleMailChimpForm]
 })``;
 
 const BodyMailChimpForm = styled(ContentModule, {
-  name: 'Hero',
+  name: 'MailchimpForm',
   slot: 'BodyMailChimpForm',
   overridesResolver: (_, styles) => [styles.bodyMailChimpForm]
 })``;
@@ -284,26 +283,26 @@ const FormContainer = styled(Grid, {
 }));
 
 const FormFieldsRoot = styled(Grid, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'FormFieldsRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.formFieldsRoot]
 })``;
 
 const FirstNameTextField = styled(TextField, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'FirstNameTextField',
   overridesResolver: (_, styles) => [styles.firstNameTextField]
 })``;
 
 const LastNameTextField = styled(TextField, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'LastNameTextField',
   overridesResolver: (_, styles) => [styles.lastNameTextField]
 })``;
 
 const EmailTextField = styled(TextField, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'EmailTextField',
   overridesResolver: (_, styles) => [styles.emailTextField]
 })``;
@@ -328,14 +327,14 @@ const SubmitContainer = styled(Grid, {
 }));
 
 const FormControl = styled(MuiFormControl, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'FormControl',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.formControl]
 })``;
 
 const Link = styled(LRFALink, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'Link',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.link]
@@ -365,20 +364,20 @@ const FormImage = styled(ContentModule, {
 }));
 
 const SuccessRoot = styled(Grid, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'SuccessRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.successRoot]
 })``;
 
 const SuccessText = styled(ContentModule, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'SuccessText',
   overridesResolver: (_, styles) => [styles.successText]
 })``;
 
 const Success = styled(Box, {
-  name: 'CustomForm',
+  name: 'Form',
   slot: 'Success',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.success]

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import { Container, Box, Grid, Typography, FormControl as MuiFormControl, TextField } from '@mui/material';
+import {
+  Container,
+  Box as MuiBox,
+  Grid as MuiGrid,
+  Typography,
+  FormControl as MuiFormControl,
+  TextField
+} from '@mui/material';
 import { useForm, Controller } from 'react-hook-form';
 import styled from '@mui/system/styled';
 import ErrorBoundary from '../ErrorBoundary';
 import LRFALink from '../Link';
 
-import ContentModule from '../ContentModule';
+import CModule from '../ContentModule';
 import MailchimpSubscribe from 'react-mailchimp-subscribe';
 import snakeCase from 'lodash/snakeCase';
 import sidekick from '@last-rev/contentful-sidekick-util';
@@ -29,7 +36,7 @@ const CustomForm = ({
   return (
     <form id={`form_${snakeCase(internalTitle)}`} onSubmit={handleSubmit(subscribe)} style={{ width: '100%' }}>
       <FormContainer container>
-        <FormFieldsRoot sx={{ px: 5, opacity: status === 'success' ? 0 : 1 }} container item xs={12} sm={8}>
+        <Grid sx={{ px: 5, opacity: status === 'success' ? 0 : 1 }} container item xs={12} sm={8}>
           {/* {status === 'error' ? <Box>Error {message}</Box> : null} */}
           <Controller
             name="FNAME"
@@ -93,11 +100,11 @@ const CustomForm = ({
               />
             )}
           />
-        </FormFieldsRoot>
+        </Grid>
         <SubmitContainer container item xs={12} sm={4} sx={{ px: 5, zIndex: 1, opacity: status === 'success' ? 0 : 1 }}>
           <FormControl>
             {actions?.map((link) => (
-              <LRFALink key={link.id} {...link} type="submit" disabled={loading} />
+              <Link key={link.id} {...link} type="submit" disabled={loading} />
             ))}
           </FormControl>
         </SubmitContainer>
@@ -114,14 +121,14 @@ const CustomForm = ({
             pointerEvents: status === 'success' ? 'initial' : 'none'
           }}>
           {successMessage ? (
-            <SuccessText
+            <ContentModule
               __typename="Text"
               variant="mailchimp-form"
               body={successMessage}
               data-testid="MailchimpForm-successMessage"
             />
           ) : (
-            <Success>Success</Success>
+            <Box>Success</Box>
           )}
         </SuccessRoot>
       </FormContainer>
@@ -192,7 +199,7 @@ export const MailchimpForm = ({
   </ErrorBoundary>
 );
 
-const Root = styled(Box, {
+const Root = styled(MuiBox, {
   name: 'MailchimpForm',
   slot: 'Root',
   shouldForwardProp: (prop) => prop !== 'variant',
@@ -210,14 +217,14 @@ const ContentContainer = styled(Container, {
   paddingBottom: theme.spacing(8)
 }));
 
-const ContentRoot = styled(Grid, {
+const ContentRoot = styled(MuiGrid, {
   name: 'MailchimpForm',
   slot: 'ContentRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.contentRoot]
 })``;
 
-const TextsRoot = styled(Grid, {
+const TextsRoot = styled(MuiGrid, {
   name: 'MailchimpForm',
   slot: 'TextsRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
@@ -236,13 +243,13 @@ const SubtitleMailChimpForm = styled(Typography, {
   overridesResolver: (_, styles) => [styles.subtitleMailChimpForm]
 })``;
 
-const BodyMailChimpForm = styled(ContentModule, {
+const BodyMailChimpForm = styled(CModule, {
   name: 'MailchimpForm',
   slot: 'BodyMailChimpForm',
   overridesResolver: (_, styles) => [styles.bodyMailChimpForm]
 })``;
 
-const FormRoot = styled(Grid, {
+const FormRoot = styled(MuiGrid, {
   name: 'MailchimpForm',
   slot: 'FormRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
@@ -251,7 +258,7 @@ const FormRoot = styled(Grid, {
 
 //Form components
 
-const FormContainer = styled(Grid, {
+const FormContainer = styled(MuiGrid, {
   name: 'Form',
   slot: 'FormContainer',
   shouldForwardProp: (prop) => prop !== 'variant',
@@ -282,11 +289,11 @@ const FormContainer = styled(Grid, {
   }
 }));
 
-const FormFieldsRoot = styled(Grid, {
+const Grid = styled(MuiGrid, {
   name: 'Form',
-  slot: 'FormFieldsRoot',
+  slot: 'Grid',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.formFieldsRoot]
+  overridesResolver: (_, styles) => [styles.grid]
 })``;
 
 const FirstNameTextField = styled(TextField, {
@@ -307,7 +314,7 @@ const EmailTextField = styled(TextField, {
   overridesResolver: (_, styles) => [styles.emailTextField]
 })``;
 
-const SubmitContainer = styled(Grid, {
+const SubmitContainer = styled(MuiGrid, {
   name: 'Form',
   slot: 'SubmitContainer',
   shouldForwardProp: (prop) => prop !== 'variant',
@@ -340,7 +347,7 @@ const Link = styled(LRFALink, {
   overridesResolver: (_, styles) => [styles.link]
 })``;
 
-const FormImage = styled(ContentModule, {
+const FormImage = styled(CModule, {
   name: 'Form',
   slot: 'Image',
   overridesResolver: (_, styles) => [styles.formImage]
@@ -363,24 +370,24 @@ const FormImage = styled(ContentModule, {
   }
 }));
 
-const SuccessRoot = styled(Grid, {
+const SuccessRoot = styled(MuiGrid, {
   name: 'Form',
   slot: 'SuccessRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.successRoot]
 })``;
 
-const SuccessText = styled(ContentModule, {
+const ContentModule = styled(CModule, {
   name: 'Form',
-  slot: 'SuccessText',
-  overridesResolver: (_, styles) => [styles.successText]
+  slot: 'ContentModule',
+  overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 
-const Success = styled(Box, {
+const Box = styled(MuiBox, {
   name: 'Form',
-  slot: 'Success',
+  slot: 'Box',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.success]
+  overridesResolver: (_, styles) => [styles.box]
 })``;
 
 export default MailchimpForm;

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
@@ -112,8 +112,7 @@ const CustomForm = ({
             height: '100%',
             opacity: status === 'success' ? 1 : 0,
             pointerEvents: status === 'success' ? 'initial' : 'none'
-          }}
-        >
+          }}>
           {successMessage ? (
             <ContentModule
               __typename="Text"
@@ -201,6 +200,7 @@ const Root = styled(Box, {
 const ContentContainer = styled(Container, {
   name: 'Form',
   slot: 'ContentContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.contentContainer]
 })<{ variant?: string }>(({ theme }) => ({
   position: 'relative',
@@ -211,6 +211,7 @@ const ContentContainer = styled(Container, {
 const FormImage = styled(ContentModule, {
   name: 'Form',
   slot: 'Image',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.formImage]
 })<{ variant?: string }>(({ theme }) => ({
   position: 'absolute',
@@ -234,6 +235,7 @@ const FormImage = styled(ContentModule, {
 const FormContainer = styled(Grid, {
   name: 'Form',
   slot: 'FormContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.formContainer]
 })<{ variant?: string }>(({ theme }) => ({
   'position': 'relative',
@@ -264,6 +266,7 @@ const FormContainer = styled(Grid, {
 const SubmitContainer = styled(Grid, {
   name: 'Form',
   slot: 'SubmitContainer',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.submitContainer]
 })<{ variant?: string }>(({ theme }) => ({
   [theme.breakpoints.down('md')]: {

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
@@ -349,7 +349,7 @@ const Link = styled(LRFALink, {
 const FormImage = styled(CModule, {
   name: 'Form',
   slot: 'Image',
-  overridesResolver: (_, styles) => [styles.formImage]
+  overridesResolver: (_, styles) => [styles.image]
 })<{ variant?: string }>(({ theme }) => ({
   position: 'absolute',
   height: '125%',

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.tsx
@@ -297,49 +297,21 @@ const FormFieldsRoot = styled(Grid, {
   overridesResolver: (_, styles) => [styles.formFieldsRoot]
 })``;
 
-// do you think the Controller component need to be a styled component?
-// since it doesnt need any css styling, im guessing not. but if you think it is, then I need some guidance with it,
-//  since when styling the component it shows an error with the control prop from the Controller
-
-// const FirstNameController = styled(Controller, {
-//   name: 'CustomForm',
-//   slot: 'FirstNameController',
-//   shouldForwardProp: (prop) => prop !== 'variant',
-//   overridesResolver: (_, styles) => [styles.firstNameController]
-// })``;
-
-// const LastNameController = styled(Controller, {
-//   name: 'CustomForm',
-//   slot: 'LastNameController',
-//   shouldForwardProp: (prop) => prop !== 'variant',
-//   overridesResolver: (_, styles) => [styles.LastNameController]
-// })``;
-
-// const EmailController = styled(Controller, {
-//   name: 'CustomForm',
-//   slot: 'EmailController',
-//   shouldForwardProp: (prop) => prop !== 'variant',
-//   overridesResolver: (_, styles) => [styles.EmailController]
-// })``;
-
 const FirstNameTextField = styled(TextField, {
   name: 'CustomForm',
   slot: 'FirstNameTextField',
-  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.firstNameTextField]
 })``;
 
 const LastNameTextField = styled(TextField, {
   name: 'CustomForm',
   slot: 'LastNameTextField',
-  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.lastNameTextField]
 })``;
 
 const EmailTextField = styled(TextField, {
   name: 'CustomForm',
   slot: 'EmailTextField',
-  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.emailTextField]
 })``;
 
@@ -415,6 +387,7 @@ const SuccessText = styled(ContentModule, {
 const Success = styled(Box, {
   name: 'CustomForm',
   slot: 'Success',
+  shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.success]
 })``;
 

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
@@ -68,7 +68,7 @@ export interface CustomFormClasses {
   /** Styles applied to the formContainer element. */
   formContainer: string;
   /** Styles applied to the formFieldsRoot element. */
-  formFieldsRoot: string;
+  grid: string;
   /** Styles applied to the firstNameTextField element. */
   firstNameTextField: string;
   /** Styles applied to the lastNameTextField element. */
@@ -84,9 +84,9 @@ export interface CustomFormClasses {
   /** Styles applied to the successRoot element. */
   successRoot: string;
   /** Styles applied to the ContentModule successText element. */
-  successText: string;
+  contentModule: string;
   /** Styles applied to the successBox element. */
-  success: string;
+  box: string;
 }
 
 export declare type MailchimpFormClassKey = keyof MailchimpFormClasses;

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
@@ -90,5 +90,5 @@ export interface CustomFormClasses {
 }
 
 export declare type MailchimpFormClassKey = keyof MailchimpFormClasses;
-declare const accordionClasses: MailchimpFormClasses;
-export default accordionClasses;
+declare const mailchimpFormClasses: MailchimpFormClasses;
+export default mailchimpFormClasses;

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
@@ -80,7 +80,7 @@ export interface CustomFormClasses {
   /** Styles applied to the link element. */
   link: string;
   /** Styles applied to the formImage element. */
-  formImage: string;
+  image: string;
   /** Styles applied to the successRoot element. */
   successRoot: string;
   /** Styles applied to the ContentModule successText element. */

--- a/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
+++ b/packages/component-library/src/components/MailchimpForm/MailchimpForm.types.ts
@@ -48,12 +48,45 @@ export interface MailchimpFormClasses {
   root: string;
   /** Styles applied to the contentContainer element. */
   contentContainer: string;
-  /** Styles applied to the formImage element. */
-  formImage: string;
+  /** Styles applied to the contentRoot element. */
+  contentRoot: string;
+  /** Styles applied to the textsRoot element. */
+  textsRoot: string;
+  /** Styles applied to the Typography of the title text element. */
+  titleMailChimpForm: string;
+  /** Styles applied to the Typography of the subtitle text element. */
+  subtitleMailChimpForm: string;
+  /** Styles applied to the ContentModule Body Text element. */
+  bodyMailChimpForm: string;
+  /** Styles applied to the formRoot element. */
+  formRoot: string;
+  /** Styles applied to the mailchimpSubscribe element. */
+  mailchimpSubscribe: string;
+}
+
+export interface CustomFormClasses {
   /** Styles applied to the formContainer element. */
   formContainer: string;
+  /** Styles applied to the formFieldsRoot element. */
+  formFieldsRoot: string;
+  /** Styles applied to the firstNameTextField element. */
+  firstNameTextField: string;
+  /** Styles applied to the lastNameTextField element. */
+  lastNameTextField: string;
+  /** Styles applied to the emailTextField element. */
+  emailTextField: string;
   /** Styles applied to the submitContainer element. */
   submitContainer: string;
+  /** Styles applied to the link element. */
+  link: string;
+  /** Styles applied to the formImage element. */
+  formImage: string;
+  /** Styles applied to the successRoot element. */
+  successRoot: string;
+  /** Styles applied to the ContentModule successText element. */
+  successText: string;
+  /** Styles applied to the successBox element. */
+  success: string;
 }
 
 export declare type MailchimpFormClassKey = keyof MailchimpFormClasses;

--- a/packages/component-library/src/components/Media/Media.tsx
+++ b/packages/component-library/src/components/Media/Media.tsx
@@ -8,10 +8,6 @@ import sidekick from '@last-rev/contentful-sidekick-util';
 
 import { MediaProps, MediaVideoProps } from './Media.types';
 import useThemeProps from '../../utils/useThemeProps';
-// import dynamic from 'next/dynamic';
-
-// const Image = dynamic(() => import('../Image'));
-// const ArtDirectedImage = dynamic(() => import('../ArtDirectedImage'));
 
 const Media = (inProps: MediaProps & MediaVideoProps) => {
   const isAmp = useAmp();
@@ -63,8 +59,7 @@ const Media = (inProps: MediaProps & MediaVideoProps) => {
           preload="auto"
           data-testid={testId || 'Media'}
           {...(props as MediaVideoProps)}
-          sx={{ width: '100%', height: '100%', ...props.sx }}
-        >
+          sx={{ width: '100%', height: '100%', ...props.sx }}>
           <source src={file?.url} />
           Your browser does not support the video tag.
         </VideoRoot>
@@ -123,21 +118,22 @@ const Root = styled(Image, {
 const ArtDirectedRoot = styled(ArtDirectedImage, {
   name: 'Media',
   slot: 'Root',
-  overridesResolver: (_, styles) => [styles.root]
+  shouldForwardProp,
+  overridesResolver: (_, styles) => [styles.artDirectedRoot]
 })<{ variant?: string }>``;
 
 const EmbedRoot = styled('iframe', {
   name: 'Media',
   slot: 'EmbedRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.root]
+  overridesResolver: (_, styles) => [styles.embedRoot]
 })``;
 
 const VideoRoot = styled('video', {
   name: 'Media',
   slot: 'VideoRoot',
   shouldForwardProp,
-  overridesResolver: (_, styles) => [styles.root]
+  overridesResolver: (_, styles) => [styles.videoRoot]
 })<{ variant?: string }>``;
 
 export default Media;

--- a/packages/component-library/src/components/Media/Media.types.ts
+++ b/packages/component-library/src/components/Media/Media.types.ts
@@ -43,6 +43,12 @@ export interface MediaVideoProps {
 export interface MediaClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the artDirectedRoot element. */
+  artDirectedRoot: string;
+  /** Styles applied to the embedRoot element. */
+  embedRoot: string;
+  /** Styles applied to the videoRoot element. */
+  videoRoot: string;
 }
 
 export declare type MediaClassKey = keyof MediaClasses;

--- a/packages/component-library/src/components/Media/Media.types.ts
+++ b/packages/component-library/src/components/Media/Media.types.ts
@@ -52,5 +52,5 @@ export interface MediaClasses {
 }
 
 export declare type MediaClassKey = keyof MediaClasses;
-declare const accordionClasses: MediaClasses;
-export default accordionClasses;
+declare const mediaClasses: MediaClasses;
+export default mediaClasses;

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Box, Grid } from '@mui/material';
+import { Box as MuiBox, Grid as MuiGrid } from '@mui/material';
 import styled from '@mui/system/styled';
 import { useTheme } from '@mui/system';
 
 import ErrorBoundary from '../ErrorBoundary';
-import ContentModule from '../ContentModule';
+import CModule from '../ContentModule';
 import sidekick from '@last-rev/contentful-sidekick-util';
 import { NavigationBarProps } from './NavigationBar.types';
 
@@ -28,10 +28,10 @@ export const NavigationBar = ({
         data-testid="NavigationBar"
         menuBreakpoint={menuBreakpoint}
         sx={color ? { backgroundColor: `${color}.main`, color: `${color}.contrastText` } : null}>
-        <NavigationBarRoot container sx={{ alignItems: 'center' }}>
+        <Grid container sx={{ alignItems: 'center' }}>
           {itemsWithVariant?.map((item) => (
             <NavigationBarItemRoot item key={item.id} sx={{ md: { justifyContent: 'center', alignItems: 'center' } }}>
-              <NavigationBarItem
+              <ContentModule
                 {...item}
                 onClick={onRequestClose}
                 color={item?.color ?? 'inherit'}
@@ -41,13 +41,13 @@ export const NavigationBar = ({
               />
             </NavigationBarItemRoot>
           ))}
-        </NavigationBarRoot>
+        </Grid>
       </Root>
     </ErrorBoundary>
   );
 };
 
-const Root = styled(Box, {
+const Root = styled(MuiBox, {
   name: 'NavigationBar',
   slot: 'Root',
   shouldForwardProp: (prop) => prop !== 'variant',
@@ -85,24 +85,24 @@ const Root = styled(Box, {
   `}
 `;
 
-const NavigationBarRoot = styled(Grid, {
+const Grid = styled(MuiGrid, {
   name: 'NavigationBar',
-  slot: 'NVRoot',
+  slot: 'Grid',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.nvRoot]
+  overridesResolver: (_, styles) => [styles.grid]
 })``;
 
-const NavigationBarItemRoot = styled(Grid, {
+const NavigationBarItemRoot = styled(MuiGrid, {
   name: 'NavigationBar',
   slot: 'ItemRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.itemRoot]
 })``;
 
-const NavigationBarItem = styled(ContentModule, {
-  name: 'NavigationBar',
+const ContentModule = styled(CModule, {
+  name: 'ContentModule',
   slot: 'Item',
-  overridesResolver: (_, styles) => [styles.item]
+  overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 
 export default NavigationBar;

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
@@ -100,8 +100,8 @@ const NavigationBarItemRoot = styled(MuiGrid, {
 })``;
 
 const ContentModule = styled(CModule, {
-  name: 'ContentModule',
-  slot: 'Item',
+  name: 'NavigationBar',
+  slot: 'ContentModule',
   overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
@@ -27,12 +27,11 @@ export const NavigationBar = ({
         variant={variant}
         data-testid="NavigationBar"
         menuBreakpoint={menuBreakpoint}
-        sx={color ? { backgroundColor: `${color}.main`, color: `${color}.contrastText` } : null}
-      >
-        <Grid container sx={{ alignItems: 'center' }}>
+        sx={color ? { backgroundColor: `${color}.main`, color: `${color}.contrastText` } : null}>
+        <NavigationBarRoot container sx={{ alignItems: 'center' }}>
           {itemsWithVariant?.map((item) => (
-            <Grid item key={item.id} sx={{ md: { justifyContent: 'center', alignItems: 'center' } }}>
-              <ContentModule
+            <NavigationBarItemRoot item key={item.id} sx={{ md: { justifyContent: 'center', alignItems: 'center' } }}>
+              <NavigationBarItem
                 {...item}
                 onClick={onRequestClose}
                 color={item?.color ?? 'inherit'}
@@ -40,9 +39,9 @@ export const NavigationBar = ({
                   onRequestClose
                 })}
               />
-            </Grid>
+            </NavigationBarItemRoot>
           ))}
-        </Grid>
+        </NavigationBarRoot>
       </Root>
     </ErrorBoundary>
   );
@@ -85,5 +84,26 @@ const Root = styled(Box, {
     }
   `}
 `;
+
+const NavigationBarRoot = styled(Grid, {
+  name: 'Hero',
+  slot: 'NavigationBarRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.navigationBarRoot]
+})``;
+
+const NavigationBarItemRoot = styled(Grid, {
+  name: 'Hero',
+  slot: 'NavigationBarItemRoot',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.navigationBarItemRoot]
+})``;
+
+const NavigationBarItem = styled(ContentModule, {
+  name: 'Hero',
+  slot: 'NavigationBarItem',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.navigationBarItem]
+})``;
 
 export default NavigationBar;

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.tsx
@@ -86,24 +86,23 @@ const Root = styled(Box, {
 `;
 
 const NavigationBarRoot = styled(Grid, {
-  name: 'Hero',
-  slot: 'NavigationBarRoot',
+  name: 'NavigationBar',
+  slot: 'NVRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.navigationBarRoot]
+  overridesResolver: (_, styles) => [styles.nvRoot]
 })``;
 
 const NavigationBarItemRoot = styled(Grid, {
-  name: 'Hero',
-  slot: 'NavigationBarItemRoot',
+  name: 'NavigationBar',
+  slot: 'ItemRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.navigationBarItemRoot]
+  overridesResolver: (_, styles) => [styles.itemRoot]
 })``;
 
 const NavigationBarItem = styled(ContentModule, {
-  name: 'Hero',
-  slot: 'NavigationBarItem',
-  shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.navigationBarItem]
+  name: 'NavigationBar',
+  slot: 'Item',
+  overridesResolver: (_, styles) => [styles.item]
 })``;
 
 export default NavigationBar;

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.types.ts
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.types.ts
@@ -13,6 +13,12 @@ export interface NavigationBarProps {
 export interface NavigationBarClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the navigationBarRoot element. */
+  navigationBarRoot: string;
+  /** Styles applied to the navigationBarItemRoot element. */
+  navigationBarItemRoot: string;
+  /** Styles applied to the navigationBarItem (Content Module) element. */
+  navigationBarItem: string;
 }
 
 export declare type NavigationBarClassKey = keyof NavigationBarClasses;

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.types.ts
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.types.ts
@@ -14,13 +14,13 @@ export interface NavigationBarClasses {
   /** Styles applied to the root element. */
   root: string;
   /** Styles applied to the navigationBarRoot element. */
-  navigationBarRoot: string;
+  nvRoot: string;
   /** Styles applied to the navigationBarItemRoot element. */
-  navigationBarItemRoot: string;
+  itemRoot: string;
   /** Styles applied to the navigationBarItem (Content Module) element. */
-  navigationBarItem: string;
+  item: string;
 }
 
 export declare type NavigationBarClassKey = keyof NavigationBarClasses;
-declare const accordionClasses: NavigationBarClasses;
-export default accordionClasses;
+declare const navigationBarClasses: NavigationBarClasses;
+export default navigationBarClasses;

--- a/packages/component-library/src/components/NavigationBar/NavigationBar.types.ts
+++ b/packages/component-library/src/components/NavigationBar/NavigationBar.types.ts
@@ -13,12 +13,12 @@ export interface NavigationBarProps {
 export interface NavigationBarClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the navigationBarRoot element. */
-  nvRoot: string;
-  /** Styles applied to the navigationBarItemRoot element. */
+  /** Styles applied to the navigationBarRoot (Grid) element. */
+  grid: string;
+  /** Styles applied to the navigationBarItemRoot (Grid) element. */
   itemRoot: string;
   /** Styles applied to the navigationBarItem (Content Module) element. */
-  item: string;
+  contentModule: string;
 }
 
 export declare type NavigationBarClassKey = keyof NavigationBarClasses;

--- a/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
+++ b/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
@@ -149,17 +149,17 @@ const MenuRoot = styled(Paper, {
 `;
 
 const MenuItem = styled(MuiMenuItem, {
-  name: 'Hero',
+  name: 'NavigationItem',
   slot: 'MenuItem',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.menuItem]
 })``;
 
 const NavigationBarItem = styled(ContentModule, {
-  name: 'Hero',
-  slot: 'NavigationBarItem',
+  name: 'NavigationItem',
+  slot: 'item',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.navigationBarItem]
+  overridesResolver: (_, styles) => [styles.item]
 })``;
 
 export default NavigationItem;

--- a/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
+++ b/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
@@ -101,7 +101,6 @@ const Root = styled(Box, {
 const NavigationItemLink = styled(ContentModule, {
   name: 'NavigationItem',
   slot: 'Link',
-  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.link]
 })<LinkProps>``;
 

--- a/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
+++ b/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MenuItem from '@mui/material/MenuItem';
+import MuiMenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import styled from '@mui/system/styled';
@@ -31,8 +31,6 @@ export const NavigationItem = ({ subNavigation, sidekickLookup, onRequestClose, 
     if (onRequestClose) onRequestClose();
   };
 
-  // console.log({ handleSubnavClick, onRequestClose });
-
   return (
     <ErrorBoundary>
       <Root sx={{ position: 'relative' }} open={open} data-testid="NavigationItem" menuBreakpoint={menuBreakpoint}>
@@ -46,7 +44,7 @@ export const NavigationItem = ({ subNavigation, sidekickLookup, onRequestClose, 
           <MenuRoot menuBreakpoint={menuBreakpoint} component={'ul'}>
             {subNavigation?.map((item) => (
               <MenuItem key={item.id}>
-                <ContentModule
+                <NavigationBarItem
                   {...item}
                   variant={'link'}
                   onClick={handleSubnavClick}
@@ -149,5 +147,19 @@ const MenuRoot = styled(Paper, {
     }
   `}
 `;
+
+const MenuItem = styled(MuiMenuItem, {
+  name: 'Hero',
+  slot: 'MenuItem',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.menuItem]
+})``;
+
+const NavigationBarItem = styled(ContentModule, {
+  name: 'Hero',
+  slot: 'NavigationBarItem',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.navigationBarItem]
+})``;
 
 export default NavigationItem;

--- a/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
+++ b/packages/component-library/src/components/NavigationItem/NavigationItem.tsx
@@ -8,7 +8,7 @@ import { useTheme } from '@mui/system';
 
 import ErrorBoundary from '../ErrorBoundary';
 import { LinkProps } from '../Link';
-import ContentModule from '../ContentModule';
+import CModule from '../ContentModule';
 import sidekick from '@last-rev/contentful-sidekick-util';
 import { NavigationItemProps } from './NavigationItem.types';
 
@@ -44,7 +44,7 @@ export const NavigationItem = ({ subNavigation, sidekickLookup, onRequestClose, 
           <MenuRoot menuBreakpoint={menuBreakpoint} component={'ul'}>
             {subNavigation?.map((item) => (
               <MenuItem key={item.id}>
-                <NavigationBarItem
+                <ContentModule
                   {...item}
                   variant={'link'}
                   onClick={handleSubnavClick}
@@ -96,7 +96,7 @@ const Root = styled(Box, {
   `}
 `;
 
-const NavigationItemLink = styled(ContentModule, {
+const NavigationItemLink = styled(CModule, {
   name: 'NavigationItem',
   slot: 'Link',
   overridesResolver: (_, styles) => [styles.link]
@@ -155,11 +155,11 @@ const MenuItem = styled(MuiMenuItem, {
   overridesResolver: (_, styles) => [styles.menuItem]
 })``;
 
-const NavigationBarItem = styled(ContentModule, {
+const ContentModule = styled(CModule, {
   name: 'NavigationItem',
-  slot: 'item',
+  slot: 'ContentModule',
   shouldForwardProp: (prop) => prop !== 'variant',
-  overridesResolver: (_, styles) => [styles.item]
+  overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 
 export default NavigationItem;

--- a/packages/component-library/src/components/NavigationItem/NavigationItem.types.ts
+++ b/packages/component-library/src/components/NavigationItem/NavigationItem.types.ts
@@ -16,7 +16,7 @@ export interface NavigationItemClasses {
   /** Styles applied to the menuItem element. */
   menuItem: string;
   /** Styles applied to the navigationBarItem (Content Module) element. */
-  item: string;
+  contentModule: string;
 }
 
 export declare type NavigationItemClassKey = keyof NavigationItemClasses;

--- a/packages/component-library/src/components/NavigationItem/NavigationItem.types.ts
+++ b/packages/component-library/src/components/NavigationItem/NavigationItem.types.ts
@@ -11,6 +11,12 @@ export interface NavigationItemClasses {
   root: string;
   /** Styles applied to the menuRoot element. */
   menuRoot: string;
+  /** Styles applied to the NavigationItemLink element. */
+  link: string;
+  /** Styles applied to the menuItem element. */
+  menuItem: string;
+  /** Styles applied to the navigationBarItem (Content Module) element. */
+  navigationBarItem: string;
 }
 
 export declare type NavigationItemClassKey = keyof NavigationItemClasses;

--- a/packages/component-library/src/components/NavigationItem/NavigationItem.types.ts
+++ b/packages/component-library/src/components/NavigationItem/NavigationItem.types.ts
@@ -16,9 +16,9 @@ export interface NavigationItemClasses {
   /** Styles applied to the menuItem element. */
   menuItem: string;
   /** Styles applied to the navigationBarItem (Content Module) element. */
-  navigationBarItem: string;
+  item: string;
 }
 
 export declare type NavigationItemClassKey = keyof NavigationItemClasses;
-declare const accordionClasses: NavigationItemClasses;
-export default accordionClasses;
+declare const navigationItemClasses: NavigationItemClasses;
+export default navigationItemClasses;

--- a/packages/component-library/src/components/SEO/SEO.types.ts
+++ b/packages/component-library/src/components/SEO/SEO.types.ts
@@ -9,5 +9,5 @@ export interface SEOClasses {
 }
 
 export declare type SEOClassKey = keyof SEOClasses;
-declare const accordionClasses: SEOClasses;
-export default accordionClasses;
+declare const seoClasses: SEOClasses;
+export default seoClasses;

--- a/packages/component-library/src/components/Section/Section.tsx
+++ b/packages/component-library/src/components/Section/Section.tsx
@@ -10,7 +10,7 @@ import get from 'lodash/get';
 // import omit from 'lodash/omit';
 
 import ErrorBoundary from '../ErrorBoundary';
-import ContentModule from '../ContentModule';
+import CModule from '../ContentModule';
 
 import sidekick from '@last-rev/contentful-sidekick-util';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -85,7 +85,7 @@ const Section = (inProps: SectionProps) => {
                     ...itemStyle
                   }}
                   data-testid="Section-ContentItem">
-                  <Content {...content} />
+                  <ContentModule {...content} />
                 </GridItem>
               );
             })}
@@ -139,7 +139,7 @@ const ContentContainer = styled(Container, {
   zIndex: 1
 }));
 
-const BackgroundMedia = styled(ContentModule, {
+const BackgroundMedia = styled(CModule, {
   name: 'Section',
   slot: 'BackgroundMedia',
   overridesResolver: (_, styles) => [styles.backgroundImage]
@@ -170,16 +170,16 @@ const GridItem = styled(Grid, {
   overridesResolver: (_, styles) => [styles.gridItem]
 })(() => ({}));
 
-const IntroText = styled(ContentModule, {
+const IntroText = styled(CModule, {
   name: 'Section',
   slot: 'IntroText',
   overridesResolver: (_, styles) => [styles.introText]
 })(() => ({}));
 
-const Content = styled(ContentModule, {
-  name: 'Hero',
-  slot: 'Content',
-  overridesResolver: (_, styles) => [styles.content]
+const ContentModule = styled(CModule, {
+  name: 'Section',
+  slot: 'ContentModule',
+  overridesResolver: (_, styles) => [styles.contentModule]
 })``;
 
 export default Section;

--- a/packages/component-library/src/components/Section/Section.tsx
+++ b/packages/component-library/src/components/Section/Section.tsx
@@ -42,6 +42,8 @@ const Section = (inProps: SectionProps) => {
   } = useThemeProps({ name: 'Section', props: inProps });
   const gridItemStyle = variant && VARIANTS_GRID_ITEM[variant] ? VARIANTS_GRID_ITEM[variant] : {};
 
+  console.log({ styles }, 'this is from section');
+
   return (
     <ErrorBoundary>
       <Root
@@ -54,21 +56,18 @@ const Section = (inProps: SectionProps) => {
         backgroundColor={backgroundColor}
         variant={variant}
         // TODO: Fix this workaround needed to prevent the theme from breaking the root styles
-        {...props}
-      >
+        {...props}>
         {background ? <BackgroundMedia {...background} /> : null}
         <ConditionalWrapper
           condition={!!contentWidth}
-          wrapper={(children) => <ContentContainer maxWidth={contentWidth}>{children}</ContentContainer>}
-        >
+          wrapper={(children) => <ContentContainer maxWidth={contentWidth}>{children}</ContentContainer>}>
           {introText && (
             <IntroText {...introText} {...sidekick(sidekickLookup?.introText)} data-testid="Section-introText" />
           )}
           <GridContainer
             container
             sx={{ ...styles?.gridContainer, flexDirection: contentDirection }}
-            {...(contentSpacing && { spacing: contentSpacing })}
-          >
+            {...(contentSpacing && { spacing: contentSpacing })}>
             {contents?.map((content, idx) => {
               const itemStyle = get(styles?.gridItems, idx);
               if (!content) return null;
@@ -87,8 +86,7 @@ const Section = (inProps: SectionProps) => {
                     ...styles?.gridItem,
                     ...itemStyle
                   }}
-                  data-testid="Section-ContentItem"
-                >
+                  data-testid="Section-ContentItem">
                   <ContentModule {...content} />
                 </GridItem>
               );
@@ -119,11 +117,13 @@ const rootStyles = ({ backgroundColor, theme }: { backgroundColor?: string; them
   return {};
 };
 
+const shouldForwardProp = (prop: string) => prop !== 'variant' && prop !== 'backgroundColor';
 // Define the pieces of the Section customizable through Theme
 
 const Root = styled(Box, {
   name: 'Section',
   slot: 'Root',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.root]
 })<{ variant?: string; backgroundColor?: string }>(() => ({
   width: '100%',
@@ -135,6 +135,7 @@ const Root = styled(Box, {
 const ContentContainer = styled(Container, {
   name: 'Section',
   slot: 'ContentContainer',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.contentContainer]
 })<{ variant?: string }>(() => ({
   zIndex: 1
@@ -143,6 +144,7 @@ const ContentContainer = styled(Container, {
 const BackgroundMedia = styled(ContentModule, {
   name: 'Section',
   slot: 'BackgroundMedia',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.backgroundImage]
 })(() => ({
   zIndex: 0,
@@ -158,6 +160,7 @@ const BackgroundMedia = styled(ContentModule, {
 const GridContainer = styled(Grid, {
   name: 'Section',
   slot: 'GridContainer',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.gridContainer]
 })(() => ({
   zIndex: 1
@@ -166,12 +169,14 @@ const GridContainer = styled(Grid, {
 const GridItem = styled(Grid, {
   name: 'Section',
   slot: 'GridItem',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.gridItem]
 })(() => ({}));
 
 const IntroText = styled(ContentModule, {
   name: 'Section',
   slot: 'IntroText',
+  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.introText]
 })(() => ({}));
 

--- a/packages/component-library/src/components/Section/Section.tsx
+++ b/packages/component-library/src/components/Section/Section.tsx
@@ -142,7 +142,6 @@ const ContentContainer = styled(Container, {
 const BackgroundMedia = styled(ContentModule, {
   name: 'Section',
   slot: 'BackgroundMedia',
-  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.backgroundImage]
 })(() => ({
   zIndex: 0,
@@ -174,7 +173,6 @@ const GridItem = styled(Grid, {
 const IntroText = styled(ContentModule, {
   name: 'Section',
   slot: 'IntroText',
-  shouldForwardProp,
   overridesResolver: (_, styles) => [styles.introText]
 })(() => ({}));
 

--- a/packages/component-library/src/components/Section/Section.tsx
+++ b/packages/component-library/src/components/Section/Section.tsx
@@ -85,7 +85,7 @@ const Section = (inProps: SectionProps) => {
                     ...itemStyle
                   }}
                   data-testid="Section-ContentItem">
-                  <ContentModule {...content} />
+                  <Content {...content} />
                 </GridItem>
               );
             })}
@@ -175,5 +175,11 @@ const IntroText = styled(ContentModule, {
   slot: 'IntroText',
   overridesResolver: (_, styles) => [styles.introText]
 })(() => ({}));
+
+const Content = styled(ContentModule, {
+  name: 'Hero',
+  slot: 'Content',
+  overridesResolver: (_, styles) => [styles.content]
+})``;
 
 export default Section;

--- a/packages/component-library/src/components/Section/Section.tsx
+++ b/packages/component-library/src/components/Section/Section.tsx
@@ -42,8 +42,6 @@ const Section = (inProps: SectionProps) => {
   } = useThemeProps({ name: 'Section', props: inProps });
   const gridItemStyle = variant && VARIANTS_GRID_ITEM[variant] ? VARIANTS_GRID_ITEM[variant] : {};
 
-  console.log({ styles }, 'this is from section');
-
   return (
     <ErrorBoundary>
       <Root

--- a/packages/component-library/src/components/Section/Section.types.ts
+++ b/packages/component-library/src/components/Section/Section.types.ts
@@ -41,5 +41,5 @@ export interface SectionClasses {
 }
 
 export declare type SectionClassKey = keyof SectionClasses;
-declare const accordionClasses: SectionClasses;
-export default accordionClasses;
+declare const sectionClasses: SectionClasses;
+export default sectionClasses;

--- a/packages/component-library/src/components/Section/Section.types.ts
+++ b/packages/component-library/src/components/Section/Section.types.ts
@@ -36,6 +36,8 @@ export interface SectionClasses {
   gridItem: string;
   /** Styles applied to the introText element. */
   introText: string;
+  /** Styles applied to the content element. */
+  content: string;
 }
 
 export declare type SectionClassKey = keyof SectionClasses;

--- a/packages/component-library/src/components/Section/Section.types.ts
+++ b/packages/component-library/src/components/Section/Section.types.ts
@@ -37,7 +37,7 @@ export interface SectionClasses {
   /** Styles applied to the introText element. */
   introText: string;
   /** Styles applied to the content element. */
-  content: string;
+  contentModule: string;
 }
 
 export declare type SectionClassKey = keyof SectionClasses;

--- a/packages/component-library/src/components/Text/Text.tsx
+++ b/packages/component-library/src/components/Text/Text.tsx
@@ -1,17 +1,15 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-
 import { documentToReactComponents, Options } from '@contentful/rich-text-react-renderer';
-
 import Box from '@mui/material/Box';
 import styled from '@mui/system/styled';
-import Typography from '@mui/material/Typography';
-import TableContainer from '@mui/material/TableContainer';
-import Table from '@mui/material/Table';
-import TableHead from '@mui/material/TableHead';
-import TableBody from '@mui/material/TableBody';
-import TableRow from '@mui/material/TableRow';
-import TableCell from '@mui/material/TableCell';
+import MuiTypography from '@mui/material/Typography';
+import MuiTableContainer from '@mui/material/TableContainer';
+import MuiTable from '@mui/material/Table';
+import MuiTableHead from '@mui/material/TableHead';
+import MuiTableBody from '@mui/material/TableBody';
+import MuiTableRow from '@mui/material/TableRow';
+import MuiTableCell from '@mui/material/TableCell';
 
 import BLOCKS from './BLOCKS';
 import INLINES from './INLINES';
@@ -62,7 +60,6 @@ const renderTypography =
             if (isHTML(child)) {
               return (
                 <Typography
-                  component="span"
                   variant={variant}
                   data-testid={`Text-html-${variant}`}
                   dangerouslySetInnerHTML={{ __html: child }}
@@ -92,9 +89,9 @@ const createRenderOptions = ({ links, renderNode, renderText }: { links?: TextLi
     renderNode: {
       [INLINES.HYPERLINK]: (_: any, children: any) => {
         return (
-          <ContentModule __typename="Link" href={_.data.uri} data-testid={`Text-${INLINES.HYPERLINK}`}>
+          <HyperLink __typename="Link" href={_.data.uri} data-testid={`Text-${INLINES.HYPERLINK}`}>
             {children}
-          </ContentModule>
+          </HyperLink>
         );
       },
       [INLINES.ENTRY_HYPERLINK]: (node: any) => {
@@ -102,34 +99,33 @@ const createRenderOptions = ({ links, renderNode, renderText }: { links?: TextLi
         const entry = entries[id];
         const content = node?.content[0]?.value;
 
-        return <ContentModule {...entry} data-testid={`Texts-${INLINES.ENTRY_HYPERLINK}`} text={content} />;
+        return <EntryHyperLink {...entry} data-testid={`Texts-${INLINES.ENTRY_HYPERLINK}`} text={content} />;
       },
       [INLINES.ASSET_HYPERLINK]: (node: any, children: any) => {
         const id: string = node?.data?.target?.sys?.id;
         const entry = assets[id];
         return (
-          <ContentModule
+          <AssetHyperLink
             __typename="Link"
             href={entry?.file?.url}
             target="_blank"
             rel="noopener noreferrer"
-            data-testid="Text-asset-hyperlink"
-          >
+            data-testid="Text-asset-hyperlink">
             {children}
-          </ContentModule>
+          </AssetHyperLink>
         );
       },
       [BLOCKS.EMBEDDED_ASSET]: (node: any) => {
         const id: string = node?.data?.target?.sys?.id;
         const entry = assets[id];
-        return <ContentModule {...entry} testId={`Text-${BLOCKS.EMBEDDED_ASSET}`} />;
+        return <EmbeddedAsset {...entry} testId={`Text-${BLOCKS.EMBEDDED_ASSET}`} />;
       },
       [BLOCKS.EMBEDDED_ENTRY]: (node: any) => {
         const id: string = node?.data?.target?.sys?.id;
         const entry = entries[id];
         return (
           <EmbeddedRoot component="span" sx={{ display: 'block' }} data-testid={`Text-${BLOCKS.EMBEDDED_ENTRY}`}>
-            <ContentModule {...entry} />
+            <EmbeddedEntry {...entry} />
           </EmbeddedRoot>
         );
       },
@@ -138,7 +134,7 @@ const createRenderOptions = ({ links, renderNode, renderText }: { links?: TextLi
         const entry = entries[id];
         return (
           <InlineRoot component="span" sx={{ display: 'inline' }} data-testid={`Text-${INLINES.EMBEDDED_ENTRY}`}>
-            <ContentModule {...entry} />
+            <InlineEntry {...entry} />
           </InlineRoot>
         );
       },
@@ -170,7 +166,7 @@ const createRenderOptions = ({ links, renderNode, renderText }: { links?: TextLi
         );
       },
       [BLOCKS.TABLE_HEADER_CELL]: (_: any, children: any) => {
-        return <TableCell>{children}</TableCell>;
+        return <TableHeaderCell>{children}</TableHeaderCell>;
       },
       [BLOCKS.TABLE_ROW]: (_: any, children: any) => {
         return <TableRow>{children}</TableRow>;
@@ -197,8 +193,7 @@ function Text({ body, align, styles, variant, sidekickLookup, sx, renderNode, re
         variant={variant}
         sx={{ textAlign: align, ...sx, ...styles?.root }}
         data-testid="Text-root"
-        {...props}
-      >
+        {...props}>
         {documentToReactComponents(
           body?.json,
           createRenderOptions({ links: body?.links, renderNode, ...renderOptions })
@@ -218,25 +213,109 @@ const Root = styled(Box, {
   white-space: pre-wrap;
 `;
 
+const Typography = styled(MuiTypography, {
+  name: 'Text',
+  slot: 'Typography',
+  overridesResolver: (_, styles) => [styles.typography]
+})``;
+
+const HyperLink = styled(ContentModule, {
+  name: 'Text',
+  slot: 'HyperLink',
+  overridesResolver: (_, styles) => [styles.hyperLink]
+})``;
+
+const EntryHyperLink = styled(ContentModule, {
+  name: 'Text',
+  slot: 'EntryHyperLink',
+  overridesResolver: (_, styles) => [styles.entryHyperLink]
+})``;
+
+const AssetHyperLink = styled(ContentModule, {
+  name: 'Text',
+  slot: 'AssetHyperLink',
+  overridesResolver: (_, styles) => [styles.assetHyperLink]
+})``;
+
+const EmbeddedAsset = styled(ContentModule, {
+  name: 'Text',
+  slot: 'EmbeddedAsset',
+  overridesResolver: (_, styles) => [styles.embeddedAsset]
+})``;
+
+const EmbeddedEntry = styled(ContentModule, {
+  name: 'Text',
+  slot: 'EmbeddedEntry',
+  overridesResolver: (_, styles) => [styles.embeddedEntry]
+})``;
+
+const InlineEntry = styled(ContentModule, {
+  name: 'Text',
+  slot: 'InlineEntry',
+  overridesResolver: (_, styles) => [styles.inlineEntry]
+})``;
+
 const EmbeddedRoot = styled(Box, {
   name: 'Text',
   slot: 'EmbeddedRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.embeddedRoot]
-})<{ variant?: string }>(() => ({}));
+})``;
 
 const InlineRoot = styled(Box, {
   name: 'Text',
   slot: 'InlineRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.inlineRoot]
-})<{ variant?: string }>(() => ({}));
+})``;
 
-const TableRoot = styled(TableContainer, {
+const TableRoot = styled(MuiTableContainer, {
   name: 'Text',
   slot: 'TableRoot',
   shouldForwardProp: (prop) => prop !== 'variant',
   overridesResolver: (_, styles) => [styles.tableRoot]
-})<{ variant?: string }>(() => ({}));
+})``;
+
+const Table = styled(MuiTable, {
+  name: 'Text',
+  slot: 'Table',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.table]
+})``;
+
+const TableHead = styled(MuiTableHead, {
+  name: 'Text',
+  slot: 'TableHead',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.tableHead]
+})``;
+
+const TableBody = styled(MuiTableBody, {
+  name: 'Text',
+  slot: 'TableBody',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.tableBody]
+})``;
+
+const TableHeaderCell = styled(MuiTableCell, {
+  name: 'Text',
+  slot: 'TableHeaderCell',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.tableHeaderCell]
+})``;
+
+const TableRow = styled(MuiTableRow, {
+  name: 'Text',
+  slot: 'TableRow',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.tableRow]
+})``;
+
+const TableCell = styled(MuiTableCell, {
+  name: 'Text',
+  slot: 'TableCell',
+  shouldForwardProp: (prop) => prop !== 'variant',
+  overridesResolver: (_, styles) => [styles.tableCell]
+})``;
 
 export default Text;

--- a/packages/component-library/src/components/Text/Text.types.ts
+++ b/packages/component-library/src/components/Text/Text.types.ts
@@ -33,6 +33,38 @@ export interface RichText {
 export interface TextClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the typography element. */
+  typography: string;
+  /** Styles applied to the hyperLink element. */
+  hyperLink: string;
+  /** Styles applied to the entryHyperLink element. */
+  entryHyperLink: string;
+  /** Styles applied to the assetHyperLink element. */
+  assetHyperLink: string;
+  /** Styles applied to the embeddedAsset element. */
+  embeddedAsset: string;
+  /** Styles applied to the embeddedEntry element. */
+  embeddedEntry: string;
+  /** Styles applied to the inlineEntry element. */
+  inlineEntry: string;
+  /** Styles applied to the embeddedRoot element. */
+  embeddedRoot: string;
+  /** Styles applied to the inlineRoot element. */
+  inlineRoot: string;
+  /** Styles applied to the tableRoot element. */
+  tableRoot: string;
+  /** Styles applied to the table element. */
+  table: string;
+  /** Styles applied to the tableHead element. */
+  tableHead: string;
+  /** Styles applied to the tableBody element. */
+  tableBody: string;
+  /** Styles applied to the tableHeaderCell element. */
+  tableHeaderCell: string;
+  /** Styles applied to the tableRow element. */
+  tableRow: string;
+  /** Styles applied to the tableCell element. */
+  tableCell: string;
 }
 
 export declare type TextClassKey = keyof TextClasses;

--- a/packages/component-library/src/components/Text/Text.types.ts
+++ b/packages/component-library/src/components/Text/Text.types.ts
@@ -68,5 +68,5 @@ export interface TextClasses {
 }
 
 export declare type TextClassKey = keyof TextClasses;
-declare const accordionClasses: TextClasses;
-export default accordionClasses;
+declare const textClasses: TextClasses;
+export default textClasses;


### PR DESCRIPTION
#### Description

### What changed?

**Card:**
1. ContentModule from CardMedia is now called **Media**
2. Skeleton is now called **MediaSkeleton**
3. ContentModule from Skeleton is now called **Media**
4. Typography(1) from CardContent is now called **CardTitle**
5. Typography(2) from CardContent is now called **CardSubtitle**
6. ContentModule from CardContent is now called **CardBody**
7. ContentModule from CardActions is now called **CardButton**
8. Typography(1) from CardContent (skeleton) is now called **CardTitle**
9. Typography(2) from CardContent (skeleton) is now called **CardSubtitle**
10. Skeleton from CardContent (skeleton) is now called **TitleSkeleton**
11. Skeleton from CardContent (skeleton) is now called **SubtitleSkeleton**
12. Skeleton from CardContent (skeleton) is now called **TextSkeleton**
13. ContentModule from CardContent (skeleton) is now called **CardBody**
14. Skeleton from CardActions (skeleton) is now called **ActionsSkeleton**

**CollectionFiltered:**
1. Grid from ContentContainer is now called **Content**
2. CollectionFilters from Grid is now called **CollectionFilteredRoot**
3. NoResultsDisplay:
    1. Grid wrapping Typography (NoResultsDisplay) is now called **NoResultsRoot**
    2. Typography from Grid is now called **NoResultsText**
    3. Skeleton from Typography is now called **NoResultsSkeleton**
4. Error:
    1. Grid wrapping Typography (Error) is now called **ErrorRoot**
    2. Typography from Grid is now called **ErrorMessage**
    3. Button from Grid is now called **ErrorButton**
5. ResultsDisplay:
    1. Grid wrapping Grid (ResultsDisplay) is now called **ResultsRoot**
    2. Grid from Grid is now called **Results**
    3. Typography from Grid is now called **ResultsText**
    4. Skeleton from Typography is now called **ResultsSkeleton**
6. LoadingResults:
    1. Grid wrapping Grid (LoadingResultsDisplay) is now called **LoadingResultsRoot**
    2. Grid from Grid is now called **LoadingResults**
    3. Typography from Grid is now called **LoadingResultsText**
    4. Skeleton from Typography is now called **LoadingResultsSkeleton**
7. LoadMore:
    1. Grid wrapping Button (LoadMore) is now called **LoadMoreRoot**
    2. Button from Grid is now called **LoadMoreButton**

**CollectionFilters:**
1. Grid from CollectionFiltersRoot is now called **CollectionFilters**
2. TextField(1) is now called **SelectTextField**
3. TextField(2) is now called **AutocompleteTextField**
4. Grid (input) is now called **InputRoot**
5. Grid wrapping Button is now called **ButtonRoot**

**Hero:**
1. ContentModule from BackgroundRoot is now called **BackgroundMedia**
2. Grid from ContentContainer is now called **ContentRoot**
3. Grid from Grid is now called **TextsContainer**
4. Grid from Grid is now called **TextsRoot**
5. Typography(1) is now called **OverlineHero**
6. Typography(2) is now called **TitleHero**
7. Typography(3) is now called **SubtitleHero**
8. ContentModule  is now called **BodyHero**
9. ContentModule from CardActions is now called **ButtonHero**
10. ContentModule from MediaRoot is now called **MediaHero**

**MailChimpForm:**
1. Grid from ContentContainer is now called **ContentRoot**
2. Grid from Grid is now called **TextsRoot**
3. Typography(1) is now called **TitleMailChimpForm**
4. Typography(2) is now called **SubtitleMailChimpForm**
5. ContentModule  is now called **BodyMailChimpForm**
6. Grid that wraps MailchimSubscribe is now called **FormRoot**
CustomForm from **MailchimpForm**
1. TextField(1) is now called **FirstNameTextField**
2. TextField(1) is now called **LastNameTextField**
3. TextField(1) is now called **EmailTextField**
4. Grid after FormImage is now called **SuccessRoot**

**NavigationBar:**
1. Grid from Grid is now called **NavigationBarItemRoot**

**Text:**
1. ContentModule (INLINES.HYPERLINK) is now called **HyperLink**
2. ContentModule (ENTRY_HYPERLINK) is now called **EntryHyperLink**
3. ContentModule (ASSET.HYPERLINK) is now called **AssetHyperLink**
4. ContentModule (EMBEDDED_ASSET) is now called **EmbeddedAsset**
5. ContentModule (EMBEDDED_ENTRY) is now called **EmbeddedEntry**
6. ContentModule  from InlineRoot is now called **InlineEntry**
7. TableCell (1) is now called **TableHeaderCell**

---

##### 🔹 Jira Ticket

https://lastrev.atlassian.net/browse/LRFA-411

##### 🔬 How to test

- Step 1
- Step 2...

##### 📸 Screenshots _(if applicable)_

---

##### Changes include

- [ ] Bug fix (_non-breaking change that solves an issue_)
- [ ] New feature (_non-breaking change that adds functionality_)
- [ ] Breaking change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation
- [ ] Release
- [ ] Other


[LRFA-411]: https://lastrev.atlassian.net/browse/LRFA-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ