### PR TITLE
separated out content and caching strategies in order to support no cache

### DIFF
--- a/.changeset/blue-snails-shave.md
+++ b/.changeset/blue-snails-shave.md
@@ -1,0 +1,9 @@
+---
+'@last-rev/app-config': minor
+'@last-rev/contentful-path-util': patch
+'@last-rev/contentful-webhook-handler': patch
+'@last-rev/graphql-contentful-helpers': patch
+'@last-rev/cli': patch
+---
+
+separated out content and caching strategies in order to support no cache

--- a/packages/app-config/src/app-config.test.tsx
+++ b/packages/app-config/src/app-config.test.tsx
@@ -12,42 +12,42 @@ describe('LastRevAppConfig', () => {
   describe('returns object with a config property with correct data', () => {
     test('cms is Contentful when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.config.cms).toBe('Contentful');
+      expect(appConfig.cms).toBe('Contentful');
     });
 
     test('stategy is fs when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.config.strategy).toBe('fs');
+      expect(appConfig.contentStrategy).toBe('fs');
     });
 
     test('logLevel is warn when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.config.logLevel).toBe('warn');
+      expect(appConfig.logLevel).toBe('warn');
     });
 
     test('graphql has port of 5000 when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.config.graphql?.port).toBe(5000);
+      expect(appConfig.graphql?.port).toBe(5000);
     });
 
     test('graphql has host of localhost when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.config.graphql?.host).toBe('localhost');
+      expect(appConfig.graphql?.host).toBe('localhost');
     });
 
     test('sites is empty array when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(JSON.stringify(appConfig.config.sites)).toBe(JSON.stringify([]));
+      expect(JSON.stringify(appConfig.sites)).toBe(JSON.stringify([]));
     });
 
     test('contentful has env of master when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.config.graphql?.port).toBe(5000);
+      expect(appConfig.graphql?.port).toBe(5000);
     });
 
     test('contentful has usePreview of false when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.config.graphql?.host).toBe('localhost');
+      expect(appConfig.graphql?.host).toBe('localhost');
     });
   });
 
@@ -252,12 +252,22 @@ describe('LastRevAppConfig', () => {
   describe('clone functionality', () => {
     test('clone merges new config with old config', () => {
       const oldConfig = mockedConfig;
-      oldConfig.redis = undefined;
-      const appConfig = new LastRevAppConfig(oldConfig);
-      expect(appConfig.config.redis).toBeUndefined();
+      const appConfig = new LastRevAppConfig({
+        ...oldConfig,
+        redis: {
+          host: 'abc',
+          port: 1234
+        }
+      });
+      expect(appConfig.redis).toEqual({
+        host: 'abc',
+        port: 1234,
+        maxBatchSize: 1000,
+        ttlSeconds: 2592000
+      });
 
       const clonedAppConfig = appConfig.clone({ ...redisConfig() });
-      expect(clonedAppConfig.config.redis).toBeDefined();
+      expect(clonedAppConfig.redis).toEqual(oldConfig.redis);
     });
   });
 
@@ -290,10 +300,31 @@ describe('LastRevAppConfig', () => {
       expect(appConfig.cms).toBe(mockedConfig.cms);
     });
 
-    test('strategy returns strategy', () => {
+    test('contentStrategy returns strategy', () => {
       mockedConfig.strategy = 'redis';
       const appConfig = new LastRevAppConfig(mockedConfig);
-      expect(appConfig.strategy).toBe(mockedConfig.strategy);
+      expect(appConfig.cmsCacheStrategy).toBe(mockedConfig.strategy);
+    });
+
+    test('cms contentStrategy returns "cms" and cmsCacheStrategy is "none"', () => {
+      mockedConfig.contentStrategy = 'cms';
+      const appConfig = new LastRevAppConfig(mockedConfig);
+      expect(appConfig.contentStrategy).toBe(mockedConfig.contentStrategy);
+      expect(appConfig.cmsCacheStrategy).toBe('none');
+    });
+
+    test('cms contentStrategy with cache strategy returns correct values', () => {
+      mockedConfig.contentStrategy = 'cms';
+      mockedConfig.cmsCacheStrategy = 'redis';
+      const appConfig = new LastRevAppConfig(mockedConfig);
+      expect(appConfig.contentStrategy).toBe(mockedConfig.contentStrategy);
+      expect(appConfig.cmsCacheStrategy).toBe(mockedConfig.cmsCacheStrategy);
+    });
+
+    test('fs contentStrategy returns "fs"', () => {
+      mockedConfig.contentStrategy = 'fs';
+      const appConfig = new LastRevAppConfig(mockedConfig);
+      expect(appConfig.contentStrategy).toBe(mockedConfig.contentStrategy);
     });
 
     test('fs returns fs', () => {

--- a/packages/app-config/src/index.ts
+++ b/packages/app-config/src/index.ts
@@ -44,32 +44,66 @@ export default class LastRevAppConfig implements LastRevAppConfiguration {
   }
 
   validateStrategy() {
-    if (this.config.strategy === 'fs') {
-      if (!this.config.fs?.contentDir) {
-        throw new Error(`FS strategy: fs.contentDir is required`);
+    if (this.config.contentStrategy) {
+      if (this.config.contentStrategy === 'fs') {
+        if (!this.config.fs?.contentDir) {
+          throw new Error(`FS strategy: fs.contentDir is required`);
+        }
+      } else if (this.config.contentStrategy === 'cms') {
+        if (this.config.cmsCacheStrategy === 'redis') {
+          if (!this.config.redis?.host) {
+            throw new Error(`Redis strategy: redis.host is required`);
+          }
+          if (!this.config.redis?.port) {
+            throw new Error(`Redis strategy: redis.port is required`);
+          }
+        } else if (this.config.cmsCacheStrategy === 'dynamodb') {
+          if (!this.config.dynamodb?.region) {
+            throw new Error(`DynamoDB strategy: dynamodb.region is required`);
+          }
+          if (!this.config.dynamodb?.accessKeyId) {
+            throw new Error(`DynamoDB strategy: dynamodb.accessKeyId is required`);
+          }
+          if (!this.config.dynamodb?.secretAccessKey) {
+            throw new Error(`DynamoDB strategy: dynamodb.secretAccessKey is required`);
+          }
+          if (!this.config.dynamodb?.tableName) {
+            throw new Error(`DynamoDB strategy: dynamodb.tableName is required`);
+          }
+        }
+      } else {
+        throw new Error(`Invalid contentStrategy: ${this.config.contentStrategy}`);
       }
-    } else if (this.config.strategy === 'redis') {
-      if (!this.config.redis?.host) {
-        throw new Error(`Redis strategy: redis.host is required`);
-      }
-      if (!this.config.redis?.port) {
-        throw new Error(`Redis strategy: redis.port is required`);
-      }
-    } else if (this.config.strategy === 'dynamodb') {
-      if (!this.config.dynamodb?.region) {
-        throw new Error(`DynamoDB strategy: dynamodb.region is required`);
-      }
-      if (!this.config.dynamodb?.accessKeyId) {
-        throw new Error(`DynamoDB strategy: dynamodb.accessKeyId is required`);
-      }
-      if (!this.config.dynamodb?.secretAccessKey) {
-        throw new Error(`DynamoDB strategy: dynamodb.secretAccessKey is required`);
-      }
-      if (!this.config.dynamodb?.tableName) {
-        throw new Error(`DynamoDB strategy: dynamodb.tableName is required`);
+    } else if (this.config.strategy) {
+      if (this.config.strategy === 'fs') {
+        if (!this.config.fs?.contentDir) {
+          throw new Error(`FS strategy: fs.contentDir is required`);
+        }
+      } else if (this.config.strategy === 'redis') {
+        if (!this.config.redis?.host) {
+          throw new Error(`Redis strategy: redis.host is required`);
+        }
+        if (!this.config.redis?.port) {
+          throw new Error(`Redis strategy: redis.port is required`);
+        }
+      } else if (this.config.strategy === 'dynamodb') {
+        if (!this.config.dynamodb?.region) {
+          throw new Error(`DynamoDB strategy: dynamodb.region is required`);
+        }
+        if (!this.config.dynamodb?.accessKeyId) {
+          throw new Error(`DynamoDB strategy: dynamodb.accessKeyId is required`);
+        }
+        if (!this.config.dynamodb?.secretAccessKey) {
+          throw new Error(`DynamoDB strategy: dynamodb.secretAccessKey is required`);
+        }
+        if (!this.config.dynamodb?.tableName) {
+          throw new Error(`DynamoDB strategy: dynamodb.tableName is required`);
+        }
+      } else {
+        throw new Error(`Invalid strategy: ${this.config.strategy}`);
       }
     } else {
-      throw new Error(`Invalid strategy: ${this.config.strategy}`);
+      throw new Error(`Must specify a content stratgy`);
     }
   }
 
@@ -112,8 +146,17 @@ export default class LastRevAppConfig implements LastRevAppConfiguration {
     return this.config.cms!;
   }
 
-  get strategy() {
-    return this.config.strategy!;
+  get contentStrategy() {
+    if (this.config.contentStrategy) return this.config.contentStrategy;
+    if (this.config.strategy !== 'fs') return 'cms';
+    return 'fs';
+  }
+
+  get cmsCacheStrategy() {
+    if (this.config.cmsCacheStrategy) return this.config.cmsCacheStrategy;
+    if (this.config.contentStrategy === 'cms') return 'none';
+    if (this.config.strategy === 'redis' || 'dynamodb') return this.config.strategy as 'redis' | 'dynamodb';
+    return 'none';
   }
 
   get fs() {

--- a/packages/app-config/src/types.ts
+++ b/packages/app-config/src/types.ts
@@ -3,12 +3,15 @@ import { LogLevelDesc } from 'loglevel';
 import { RedisOptions } from 'ioredis';
 
 export type LastRevStrategy = 'fs' | 'redis' | 'dynamodb';
+export type ContentStrategy = 'fs' | 'cms';
+export type CmsCacheStrategy = 'redis' | 'dynamodb' | 'none';
 
 export type PathVersion = 'v1' | 'v2';
 
 export interface LastRevAppConfiguration {
   cms: 'Contentful';
-  strategy: LastRevStrategy;
+  contentStrategy: ContentStrategy;
+  cmsCacheStrategy: CmsCacheStrategy;
   redis: RedisOptions & {
     maxBatchSize: number;
     ttlSeconds: number;
@@ -54,7 +57,12 @@ export interface LastRevAppConfiguration {
 
 export type LastRevAppConfigArgs = {
   cms?: 'Contentful';
+  /*
+    @deprecated use contentStrategy and cmsCacheStrategy instead
+  */
   strategy?: LastRevStrategy;
+  contentStrategy?: ContentStrategy;
+  cmsCacheStrategy?: CmsCacheStrategy;
   redis?: RedisOptions & {
     maxBatchSize?: number;
     ttlSeconds?: number;

--- a/packages/contentful-path-util/src/PathStore.ts
+++ b/packages/contentful-path-util/src/PathStore.ts
@@ -159,12 +159,27 @@ export class DynamoDbPathStore implements PathStore {
   };
 }
 
+export class DummyStore implements PathStore {
+  load = async () => {
+    return {};
+  };
+
+  save = async () => {};
+}
+
 export const createPathStore = (config: LastRevAppConfig) => {
-  switch (config.strategy) {
-    case 'redis':
-      return new RedisPathStore(config);
-    case 'dynamodb':
-      return new DynamoDbPathStore(config);
+  switch (config.contentStrategy) {
+    case 'cms': {
+      switch (config.cmsCacheStrategy) {
+        case 'redis':
+          return new RedisPathStore(config);
+        case 'dynamodb':
+          return new DynamoDbPathStore(config);
+        case 'none':
+          // path reader only works with pre-calculated paths in redis/dynamodb/fs
+          return new DummyStore();
+      }
+    }
     case 'fs':
       return new FsPathStore(config);
   }

--- a/packages/contentful-webhook-handler/src/handlers.ts
+++ b/packages/contentful-webhook-handler/src/handlers.ts
@@ -4,12 +4,14 @@ import { createRedisHandlers } from './redisHandlers';
 import { createDynamoDbHandlers } from './dynamodbHandlers';
 
 export const createHandlers = (config: LastRevAppConfig): Handlers => {
-  switch (config.strategy) {
+  switch (config.cmsCacheStrategy) {
     case 'redis':
       return createRedisHandlers(config);
     case 'dynamodb':
       return createDynamoDbHandlers(config);
+    case 'none':
+      throw new Error('cmsCacheStrategy "none" does not need a webhook handler');
     default:
-      throw new Error(`Unknown or unsuported strategy ${config.strategy}`);
+      throw new Error(`Unknown or unsuported cmsCacheStrategy ${config.cmsCacheStrategy}`);
   }
 };

--- a/packages/graphql-contentful-helpers/src/createLoaders.ts
+++ b/packages/graphql-contentful-helpers/src/createLoaders.ts
@@ -10,13 +10,16 @@ const createLoaders = (config: LastRevAppConfig, defaultLocale: string): Content
   let loaders;
 
   const cmsLoaders = createCmsLoaders(config, defaultLocale);
-  if (config.strategy === 'fs') {
+
+  if (config.contentStrategy === 'fs') {
     loaders = createFsLoaders(config, cmsLoaders);
   } else {
-    if (config.strategy === 'redis') {
+    if (config.cmsCacheStrategy === 'redis') {
       loaders = createRedisLoaders(config, cmsLoaders);
-    } else if (config.strategy === 'dynamodb') {
+    } else if (config.cmsCacheStrategy === 'dynamodb') {
       loaders = createDynamoDbLoaders(config, cmsLoaders);
+    } else if (config.cmsCacheStrategy === 'none') {
+      loaders = cmsLoaders;
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2463,22 +2463,6 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
-"@last-rev/contentful-path-util@^0.1.16":
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/@last-rev/contentful-path-util/-/contentful-path-util-0.1.16.tgz#93b09563c4d0b035bfd8c2b2f38118cd14ef107e"
-  integrity sha512-dWL+0+K0+oJY9euOwf+G44zgn80KAk+2gmUwtstETk47BJu9rSy7wS9ciow87E8NdsbD0K6MNJyqUOVuuJabHA==
-  dependencies:
-    "@last-rev/contentful-path-rules-engine" "^0.1.2"
-    "@last-rev/timer" "^0.1.3"
-    async-lock "^1.3.0"
-    aws-sdk "^2.1012.0"
-    contentful "^8.4.2"
-    fs-extra "^10.0.0"
-    ioredis "^5.0.4"
-    lodash "^4.17.21"
-    loglevel "^1.7.1"
-    tslib "^2.3.0"
-
 "@last-rev/contentful-s3-sync@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@last-rev/contentful-s3-sync/-/contentful-s3-sync-0.1.2.tgz#4701b388d506a5af1a7eb24b0178bf32072b2310"


### PR DESCRIPTION
two new fields on config: contentStrategy (fs/cms) and cmsCacheStrategy (redis/dynamodb/none). using the old strategy will still work, but will map these to the new variables:

for example: `{ strategy = "redis" }` becomes `{ contentStrategy="cms", cmsCacheStrategy="redis" }`