### PR TITLE
Update run-web-tests.yml example to use reusable workflow

### DIFF
--- a/examples/lastrev-next-starter/.github/workflows/run-web-tests.yml
+++ b/examples/lastrev-next-starter/.github/workflows/run-web-tests.yml
@@ -1,174 +1,19 @@
-name: E2E Tests
+name: 🧪 E2E Tests - Cypress
 
 on:
   push:
     branches: [main]
   pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
-  # Used as a webhook event for publish success actions
-  repository_dispatch:
-  # Used to fire tests manually from Github
-  workflow_dispatch:
-    inputs:
-      baseURL:
-        default: 'https://starter.lastrev.com'
-        type: string
-        description: 'Base URL to run the test against'
-        required: true
-      environment:
-        description: 'Environment to run the tests against'
-        type: environment
-        required: false
-      parallelCount:
-        description: 'Count of parallel instances to use'
-        type: environment
-        required: false
+    types: [labeled, opened, synchronize]
 
 jobs:
-  # Nonce for re-runs: https://docs.percy.io/docs/parallel-test-suites#github-actions
-  nonce:
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ steps.nonce.outputs.result }}
-    steps:
-      - id: nonce
-        run: echo "::set-output name=result::${{ github.run_id }}-$(date +%s)"
-
-  install:
-    runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.14.0-slim-chrome99-ff97
-      options: --user 1001
-    steps:
-      # Enforce label on PR to prevent unnecesary testing
-      - name: Enforce labels
-        uses: mheap/github-action-required-labels@v1
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          mode: exactly
-          count: 1
-          labels: 'qa-ready'
-
-      ## SETUP
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Dependencies cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            **/node_modules
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: ./node_modules/.cache/turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-
-
-      - name: Install project dependencies
-        run: yarn --prefer-offline
-
-      # report machine parameters
-      - run: npx cypress info
-      # - run: node -p 'os.cpus()'
-      # - run: yarn types
-      # - run: yarn lint
-      # - run: yarn test:unit:ci
-      # - run: yarn turbo run build
-
-      # - name: Save build folder
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: build
-      #     if-no-files-found: error
-      #     path: build
-
-  ui-chrome-tests:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.14.0-slim-chrome99-ff97
-      options: --user 1001
-    needs:
-      - install
-      - nonce
-    strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving the Dashboard hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
-      matrix:
-        # run copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5]
-
-    steps:
-      ## SETUP
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Dependencies cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            **/node_modules
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v2
-        with:
-          path: ./node_modules/.cache/turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-
-
-      - name: Install project dependencies
-        run: yarn --prefer-offline
-
-      - name: Wait for Netlify Deploy Preview Commit
-        uses: jlevy-io/wait-for-netlify-deploy-with-headers@3.0.2
-        id: wait-for-netflify-preview
-        with:
-          site_id: ${{ secrets.NETLIFY_SITE_ID }}
-        env:
-          NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
-
-      - name: 'Website Tests - Chrome'
-        uses: cypress-io/github-action@v4
-        with:
-          install: false
-          project: ./packages/web
-          command-prefix: 'percy exec -- npx'
-          # wait-on: http://localhost:5338/percy/healthcheck
-          # wait-on-timeout: 120
-          browser: chrome
-          record: true
-          parallel: true
-          group: 'UI - Chrome'
-        env:
-          SITE: ${{ secrets.SITE }}
-          CYPRESS_BASE_URL: ${{ steps.wait-for-netflify-preview.outputs.url }}
-          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}
-          PERCY_PARALLEL_TOTAL: 5
-          COMMIT_INFO_BRANCH: ${{ github.head_ref }}
-          # Recommended: pass the GitHub token lets this action correctly
-          # determine the unique run id necessary to re-run the checks
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  lr-e2e-tests:
+    uses: last-rev-llc/workflows/.github/workflows/e2e.yml@main
+    with:
+      provider: 'netlify' # Or 'vercel'
+      parallel-jobs: 10
+    secrets:
+      CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      SITE: ${{ secrets.SITE }}


### PR DESCRIPTION
#### Description

This PR updates the default github workflow used on new projects created through the starter so they use the reusable workflow instead. This will make any new project easier to set up and will leverage a more robust CI pipeline without having to manually make changes to fit different clients.

---

##### 🔹 Jira Ticket

N/A

##### 🔬 How to test

N/A

##### 📸 Screenshots _(if applicable)_

---

##### Changes include

- [ ] Bug fix (_non-breaking change that solves an issue_)
- [ ] New feature (_non-breaking change that adds functionality_)
- [ ] Breaking change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation
- [ ] Release
- [ ] Other
