### PR TITLE
Removed locales from initial ID queries

### DIFF
--- a/.changeset/wicked-ants-promise.md
+++ b/.changeset/wicked-ants-promise.md
@@ -1,0 +1,5 @@
+---
+'@last-rev/graphql-algolia-integration': patch
+---
+
+Fixed a bug where we were looping through locales and generating way too many lists of IDs

--- a/packages/graphql-algolia-integration/src/types.ts
+++ b/packages/graphql-algolia-integration/src/types.ts
@@ -13,5 +13,5 @@ export type AlgoliaObjectsByIndex = {
 
 export type QueryConfig = {
   preview: boolean;
-  locale: string;
+  locale?: string;
 };


### PR DESCRIPTION
We were making way too many queries because we were including locales in the ids query. fixed this.