### PR TITLE
Add basic Sanity CMS loader

### DIFF
--- a/packages/sanity-cms-loader/CHANGELOG.md
+++ b/packages/sanity-cms-loader/CHANGELOG.md
@@ -1,0 +1,107 @@
+# @last-rev/contentful-cms-loader
+
+## 0.5.0
+
+### Minor Changes
+
+- 6c0dc760: Updated packages with vulnerabilities to the safest
+
+## 0.4.3
+
+### Patch Changes
+
+- 69551c0: Updated @last-rev/logging package
+
+## 0.4.2
+
+### Patch Changes
+
+- e7fb567: Fixed a bug iin the refby loader
+
+## 0.4.1
+
+### Patch Changes
+
+- 86a8923: 'Switched to winston logger and added a remote datadog transport'
+- Updated dependencies [86a8923]
+  - @last-rev/logging@0.1.1
+  - @last-rev/timer@0.2.0
+
+## 0.4.0
+
+### Minor Changes
+
+- a996010: Added a new entryByFieldBValue loader
+- a996010: Added contentful path rules engine and support for it in various packages
+
+## 0.3.0
+
+### Minor Changes
+
+- fc0aab6: Added a new entryByFieldBValue loader
+
+## 0.2.2
+
+### Patch Changes
+
+- 3ba98cd: Bump testing-library version
+- Updated dependencies [3ba98cd]
+  - @last-rev/timer@0.1.3
+
+## 0.2.1
+
+### Patch Changes
+
+- f7e8fa4: Fixed some issues with redis and cms loading. chunking some requests.
+
+## 0.2.0
+
+### Minor Changes
+
+- 25375f1: Added resolveLinks:false to all contentful createClient calls in the framework
+
+## 0.1.7
+
+### Patch Changes
+
+- dd98970: Fixed an error where invalid contentful queries were leading to failed webhook update
+
+## 0.1.6
+
+### Patch Changes
+
+- d6ec293: Added Algolia integration, cleaned up logs
+
+## 0.1.5
+
+### Patch Changes
+
+- b3c20e0: Update to latest rollup-config
+- Updated dependencies [b3c20e0]
+  - @last-rev/timer@0.1.2
+
+## 0.1.4
+
+### Patch Changes
+
+- d88df66: Added cacheKeyFn to all loaders to fix caching issues
+
+## 0.1.3
+
+### Patch Changes
+
+- 5ee84d6: Moved App Config to its own package, created contentful-path-util, and created contentful-webhook-handler
+
+## 0.1.2
+
+### Patch Changes
+
+- 7b9d6a1: Added Redis Cache loader, and cleaned up dependencies
+- Updated dependencies [7b9d6a1]
+  - @last-rev/timer@0.1.1
+
+## 0.1.1
+
+### Patch Changes
+
+- 6e8e402: Moved preview boolean into graphql queries

--- a/packages/sanity-cms-loader/README.md
+++ b/packages/sanity-cms-loader/README.md
@@ -1,0 +1,31 @@
+# Overview
+
+This library exports a single default function which creates a set of data loaders and fetchers for loading sanity structured content from Sanity's CDN.
+
+# Usage
+
+```Javascript
+import createLoaders from '@last-rev/sanity-cms-loader';
+
+async function () {
+  const {
+    entryLoader,
+    assetLoader,
+    entriesByContentTypeLoader,
+    fetchAllPages,
+    fetchAllContentTypes
+  } = await createLoaders(
+    // TODO
+  );
+}
+```
+
+`entryLoader`, `assetLoader`, and `entriesByContentTypeLoader` are all instances of [dataloader](https://github.com/graphql/dataloader). `entryLoader` and `assetLoader` are both keyed by Sanity ID (`string`), and `entriesByContentTypeLoader` is keyed by a Sanity content type ID (`string`).
+
+```Javascript
+const myEntry = await entryLoader('my-content-id-1234');
+const myAsset = await assetLoader('my-asset-id-5432');
+const myEntries =  await entriesByContentTypeLoader('pageGeneral');
+```
+
+the other two functions, `fetchAllPages` and `fetchAllContent` are just convenience functions that return a list of all page content items (entries which have a slug field) and all content types.

--- a/packages/sanity-cms-loader/jest.config.js
+++ b/packages/sanity-cms-loader/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@last-rev/testing-library').config();

--- a/packages/sanity-cms-loader/package.json
+++ b/packages/sanity-cms-loader/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@last-rev/sanity-cms-loader",
+  "version": "0.1.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "run-s clean build:prod",
+    "dev": "cross-env NODE_ENV=development rollup -cw",
+    "build:prod": "cross-env NODE_ENV=production rollup -c",
+    "lint": "tslint --project tsconfig.json",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch"
+  },
+  "devDependencies": {
+    "@last-rev/app-config": "^0.5.0",
+    "@last-rev/rollup-config": "^0.1.4",
+    "@last-rev/testing-library": "^0.1.10",
+    "@last-rev/types": "^0.4.0",
+    "@sanity/client": "^5.8.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@last-rev/logging": "^0.1.3",
+    "@last-rev/timer": "^0.2.0",
+    "dataloader": "^2.0.0",
+    "lodash": "^4.17.21",
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/sanity-cms-loader/rollup.config.js
+++ b/packages/sanity-cms-loader/rollup.config.js
@@ -1,0 +1,6 @@
+import { config } from '@last-rev/rollup-config';
+
+export default config({
+  input: `./src/index.ts`,
+  babelHelpers: 'runtime'
+});

--- a/packages/sanity-cms-loader/src/constants.ts
+++ b/packages/sanity-cms-loader/src/constants.ts
@@ -1,0 +1,1 @@
+export const LOG_PREFIX = '[sanity-cms-loader]';

--- a/packages/sanity-cms-loader/src/index.ts
+++ b/packages/sanity-cms-loader/src/index.ts
@@ -1,0 +1,159 @@
+import DataLoader, { Options } from 'dataloader';
+import { createClient, SanityClient } from '@sanity/client';
+import { map, partition } from 'lodash';
+import { getWinstonLogger } from '@last-rev/logging';
+import Timer from '@last-rev/timer';
+import { ItemKey, ContentfulLoaders, FVLKey, RefByKey } from '@last-rev/types';
+import LastRevAppConfig from '@last-rev/app-config';
+
+const logger = getWinstonLogger({ package: 'sanity-cms-loader', module: 'index', strategy: 'Cms' });
+
+const options: Options<ItemKey, any, string> = {
+  cacheKeyFn: (key: ItemKey) => {
+    return key.preview ? `${key.id}-preview` : `${key.id}-prod`;
+  }
+};
+
+const fvlOptions: Options<FVLKey, any, string> = {
+  cacheKeyFn: (key: FVLKey) => {
+    const baseKey = `${key.contentType}-${key.field}-${key.value}`;
+    return key.preview ? `${baseKey}-preview` : `${baseKey}-prod`;
+  }
+};
+
+const refByOptions: Options<RefByKey, any, string> = {
+  cacheKeyFn: (key: RefByKey) => {
+    const baseKey = `${key.contentType}-${key.field}-${key.id}`;
+    return key.preview ? `${baseKey}-preview` : `${baseKey}-prod`;
+  }
+};
+
+const createLoaders = (config: LastRevAppConfig): ContentfulLoaders => {
+  const sanity = (config as any).sanity || {};
+
+  const prodClient = createClient({
+    projectId: sanity.projectId,
+    dataset: sanity.dataset,
+    apiVersion: sanity.apiVersion || '2021-10-21',
+    useCdn: true
+  });
+
+  const previewClient = createClient({
+    projectId: sanity.projectId,
+    dataset: sanity.dataset,
+    apiVersion: sanity.apiVersion || '2021-10-21',
+    token: sanity.previewToken,
+    useCdn: false
+  });
+
+  const fetchBatchItems = async (ids: string[], client: SanityClient) => {
+    if (!ids.length) return [] as any[];
+    const query = '*[_id in $ids]';
+    return client.fetch(query, { ids });
+  };
+
+  const getBatchItemFetcher = (): DataLoader.BatchLoadFn<ItemKey, any | null> => {
+    return async (keys) => {
+      const timer = new Timer();
+      const [previewKeys, prodKeys] = partition(keys, (k) => k.preview);
+      const [previewDocs, prodDocs] = await Promise.all([
+        fetchBatchItems(map(previewKeys, 'id'), previewClient),
+        fetchBatchItems(map(prodKeys, 'id'), prodClient)
+      ]);
+      const all = [...previewDocs, ...prodDocs];
+      const items = keys.map(({ id }) => all.find((d) => d && d._id === id) || null);
+      logger.debug('Fetched docs', {
+        caller: 'getBatchItemFetcher',
+        elapsedMs: timer.end().millis,
+        itemsAttempted: keys.length,
+        itemsSuccessful: items.filter((x) => x).length
+      });
+      return items;
+    };
+  };
+
+  const getBatchEntriesByContentTypeFetcher = (): DataLoader.BatchLoadFn<ItemKey, any[]> => {
+    return async (keys) => {
+      const timer = new Timer();
+      const results = await Promise.all(
+        keys.map(async ({ id, preview }) => {
+          const client = preview ? previewClient : prodClient;
+          const query = '*[_type == $type]';
+          const docs = await client.fetch(query, { type: id });
+          return docs as any[];
+        })
+      );
+      logger.debug('Fetched docs by type', {
+        caller: 'getBatchEntriesByContentTypeFetcher',
+        elapsedMs: timer.end().millis,
+        itemsAttempted: keys.length,
+        itemsSuccessful: results.reduce((a, c) => a + c.length, 0)
+      });
+      return results;
+    };
+  };
+
+  const getBatchEntriesByFieldValueFetcher = (): DataLoader.BatchLoadFn<FVLKey, any | null> => {
+    return async (keys) => {
+      const timer = new Timer();
+      const results = await Promise.all(
+        keys.map(async ({ contentType, field, value, preview }) => {
+          const client = preview ? previewClient : prodClient;
+          const query = `*[_type == $type && ${field} == $value][0]`;
+          const doc = await client.fetch(query, { type: contentType, value });
+          return doc || null;
+        })
+      );
+      logger.debug('Fetched doc by field value', {
+        caller: 'getBatchEntriesByFieldValueFetcher',
+        elapsedMs: timer.end().millis,
+        itemsAttempted: keys.length,
+        itemsSuccessful: results.filter((x) => x).length
+      });
+      return results;
+    };
+  };
+
+  const getBatchEntriesRefByFetcher = (): DataLoader.BatchLoadFn<RefByKey, any[]> => {
+    return async (keys) => {
+      const timer = new Timer();
+      const results = await Promise.all(
+        keys.map(async ({ contentType, field, id, preview }) => {
+          const client = preview ? previewClient : prodClient;
+          const query = `*[_type == $type && (${field}._ref == $id || $id in ${field}[]._ref)]`;
+          const docs = await client.fetch(query, { type: contentType, id });
+          return docs as any[];
+        })
+      );
+      logger.debug('Fetched docs ref by', {
+        caller: 'getBatchEntriesRefByFetcher',
+        elapsedMs: timer.end().millis,
+        itemsAttempted: keys.length,
+        itemsSuccessful: results.reduce((a, c) => a + c.length, 0)
+      });
+      return results;
+    };
+  };
+
+  const entryLoader = new DataLoader(getBatchItemFetcher(), options);
+  const assetLoader = new DataLoader(getBatchItemFetcher(), options);
+  const entriesByContentTypeLoader = new DataLoader(getBatchEntriesByContentTypeFetcher(), options);
+  const entryByFieldValueLoader = new DataLoader(getBatchEntriesByFieldValueFetcher(), fvlOptions);
+  const entriesRefByLoader = new DataLoader(getBatchEntriesRefByFetcher(), refByOptions);
+
+  const fetchAllContentTypes = async (_preview: boolean) => {
+    logger.warn('fetchAllContentTypes not implemented for Sanity');
+    return [] as any[];
+  };
+
+  return {
+    entryLoader,
+    assetLoader,
+    entriesByContentTypeLoader,
+    entryByFieldValueLoader,
+    entriesRefByLoader,
+    fetchAllContentTypes
+  };
+};
+
+export default createLoaders;

--- a/packages/sanity-cms-loader/tsconfig.json
+++ b/packages/sanity-cms-loader/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist",
+    "declarationDir": "dist",
+    "module": "esnext",
+    "target": "es2020",
+    "lib": ["es6", "dom", "es2016", "es2017", "es2020"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add new `sanity-cms-loader` package mirroring Contentful loader API
- implement DataLoader utilities using `@sanity/client`

## Testing
- `yarn workspace @last-rev/sanity-cms-loader build` *(fails: fetch from registry blocked)*
- `yarn test` *(fails: fetch from registry blocked)*