### PR TITLE
Add Sanity CMS support

### DIFF
--- a/packages/app-config/src/app-config.mock.ts
+++ b/packages/app-config/src/app-config.mock.ts
@@ -29,8 +29,19 @@ const contentful = () => ({
   maxBatchSize: 500
 });
 
+const sanity = () => ({
+  projectId: 'projectId',
+  dataset: 'dataset',
+  token: 'token',
+  apiVersion: '2021-06-07'
+});
+
 export const redisConfig = (): LastRevAppConfigArgs => ({
   redis: { ...redis() }
+});
+
+export const sanityConfig = (): LastRevAppConfigArgs => ({
+  sanity: { ...sanity() }
 });
 
 export default (): LastRevAppConfigArgs => ({
@@ -38,6 +49,7 @@ export default (): LastRevAppConfigArgs => ({
   dynamodb: { ...dynamodb() },
   fs: { ...fs() },
   contentful: { ...contentful() },
+  sanity: { ...sanity() },
   extensions: {
     typeDefs: 'typeDefs',
     resolvers: {},

--- a/packages/app-config/src/app-config.test.tsx
+++ b/packages/app-config/src/app-config.test.tsx
@@ -21,6 +21,12 @@ describe('LastRevAppConfig', () => {
       expect(appConfig.cms).toBe('Contentful');
     });
 
+    test('cms is Sanity when provided', () => {
+      mockedConfig.cms = 'Sanity';
+      const appConfig = new LastRevAppConfig(mockedConfig);
+      expect(appConfig.cms).toBe('Sanity');
+    });
+
     test('stategy is fs when not provided', () => {
       const appConfig = new LastRevAppConfig(mockedConfig);
       expect(appConfig.contentStrategy).toBe('fs');
@@ -114,6 +120,46 @@ describe('LastRevAppConfig', () => {
       }
       expect(() => new LastRevAppConfig(mockedConfig)).toThrowError(
         'Contentful CMS: contentful.contentPreviewToken is required.'
+      );
+    });
+
+    test('throws error if sanity.projectId is not provided', () => {
+      mockedConfig.cms = 'Sanity';
+      if (mockedConfig.sanity) {
+        mockedConfig.sanity.projectId = undefined;
+      }
+      expect(() => new LastRevAppConfig(mockedConfig)).toThrowError(
+        'Sanity CMS: sanity.projectId is required.'
+      );
+    });
+
+    test('throws error if sanity.dataset is not provided', () => {
+      mockedConfig.cms = 'Sanity';
+      if (mockedConfig.sanity) {
+        mockedConfig.sanity.dataset = undefined;
+      }
+      expect(() => new LastRevAppConfig(mockedConfig)).toThrowError(
+        'Sanity CMS: sanity.dataset is required.'
+      );
+    });
+
+    test('throws error if sanity.token is not provided', () => {
+      mockedConfig.cms = 'Sanity';
+      if (mockedConfig.sanity) {
+        mockedConfig.sanity.token = undefined;
+      }
+      expect(() => new LastRevAppConfig(mockedConfig)).toThrowError(
+        'Sanity CMS: sanity.token is required.'
+      );
+    });
+
+    test('throws error if sanity.apiVersion is not provided', () => {
+      mockedConfig.cms = 'Sanity';
+      if (mockedConfig.sanity) {
+        mockedConfig.sanity.apiVersion = undefined;
+      }
+      expect(() => new LastRevAppConfig(mockedConfig)).toThrowError(
+        'Sanity CMS: sanity.apiVersion is required.'
       );
     });
 
@@ -284,6 +330,12 @@ describe('LastRevAppConfig', () => {
       }
       const appConfig = new LastRevAppConfig(mockedConfig);
       expect(JSON.stringify(appConfig.contentful)).toBe(JSON.stringify(appConfig.contentful));
+    });
+
+    test('sanity returns sanity object', () => {
+      mockedConfig.cms = 'Sanity';
+      const appConfig = new LastRevAppConfig(mockedConfig);
+      expect(JSON.stringify(appConfig.sanity)).toBe(JSON.stringify(appConfig.sanity));
     });
 
     test('logLevel returns logLevel', () => {

--- a/packages/app-config/src/index.ts
+++ b/packages/app-config/src/index.ts
@@ -40,6 +40,19 @@ export default class LastRevAppConfig implements LastRevAppConfiguration {
       if (!this.config.contentful?.contentPreviewToken) {
         throw new Error('Contentful CMS: contentful.contentPreviewToken is required.');
       }
+    } else if (this.config.cms === 'Sanity') {
+      if (!this.config.sanity?.projectId) {
+        throw new Error('Sanity CMS: sanity.projectId is required.');
+      }
+      if (!this.config.sanity?.dataset) {
+        throw new Error('Sanity CMS: sanity.dataset is required.');
+      }
+      if (!this.config.sanity?.token) {
+        throw new Error('Sanity CMS: sanity.token is required.');
+      }
+      if (!this.config.sanity?.apiVersion) {
+        throw new Error('Sanity CMS: sanity.apiVersion is required.');
+      }
     } else {
       throw new Error(`Invalid CMS: ${this.config.cms}`);
     }
@@ -132,6 +145,15 @@ export default class LastRevAppConfig implements LastRevAppConfiguration {
       usePreview: !!this.config.contentful?.usePreview,
       maxBatchSize: this.config.contentful?.maxBatchSize || 1000,
       syncLimit: this.config.contentful?.syncLimit
+    };
+  }
+
+  get sanity() {
+    return {
+      projectId: this.config.sanity?.projectId!,
+      dataset: this.config.sanity?.dataset!,
+      token: this.config.sanity?.token!,
+      apiVersion: this.config.sanity?.apiVersion!
     };
   }
 

--- a/packages/app-config/src/types.ts
+++ b/packages/app-config/src/types.ts
@@ -9,7 +9,7 @@ export type CmsCacheStrategy = 'redis' | 'dynamodb' | 'none';
 export type PathVersion = 'v1' | 'v2';
 
 export interface LastRevAppConfiguration {
-  cms: 'Contentful';
+  cms: 'Contentful' | 'Sanity';
   contentStrategy: ContentStrategy;
   cmsCacheStrategy: CmsCacheStrategy;
   jwtSigningSecret?: string;
@@ -34,6 +34,12 @@ export interface LastRevAppConfiguration {
     usePreview: boolean;
     maxBatchSize: number;
     syncLimit?: number;
+  };
+  sanity: {
+    projectId: string;
+    dataset: string;
+    token: string;
+    apiVersion: string;
   };
   algolia: {
     applicationId: string;
@@ -71,7 +77,7 @@ type LRApolloServerOptions = Partial<ApolloServerOptions<ApolloContext>> & {
   context?: ContextFunction<any, ApolloContext>;
 };
 export type LastRevAppConfigArgs = {
-  cms?: 'Contentful';
+  cms?: 'Contentful' | 'Sanity';
   /*
     @deprecated use contentStrategy and cmsCacheStrategy instead
   */
@@ -100,6 +106,12 @@ export type LastRevAppConfigArgs = {
     usePreview?: boolean;
     maxBatchSize?: number;
     syncLimit?: number;
+  };
+  sanity?: {
+    projectId?: string;
+    dataset?: string;
+    token?: string;
+    apiVersion?: string;
   };
   algolia?: {
     applicationId?: string;


### PR DESCRIPTION
## Summary
- allow `cms` to be `Contentful` or `Sanity`
- add sanity config section
- validate Sanity config fields
- export sanity getter
- extend mocks and tests

## Testing
- `yarn workspace @last-rev/app-config test` *(fails: network access needed)*