### PR TITLE
Add Sanity CMS support

### DIFF
--- a/packages/graphql-contentful-helpers/package.json
+++ b/packages/graphql-contentful-helpers/package.json
@@ -32,6 +32,7 @@
     "@last-rev/contentful-path-util": "^0.2.0",
     "@last-rev/timer": "^0.2.0",
     "@last-rev/types": "^0.4.0",
+    "@sanity/client": "^5.3.4",
     "contentful": "^9.3.6",
     "lodash": "^4.17.21"
   }

--- a/packages/graphql-contentful-helpers/src/createPathReaders.ts
+++ b/packages/graphql-contentful-helpers/src/createPathReaders.ts
@@ -3,6 +3,10 @@ import { createPathStore, PathReader } from '@last-rev/contentful-path-util';
 import LastRevAppConfig from '@last-rev/app-config';
 
 const createPathReaders = (config: LastRevAppConfig): PathReaders | undefined => {
+  if (config.cms === 'Sanity') {
+    return undefined;
+  }
+
   if (config.paths.generateFullPathTree) {
     const [previewPathStore, prodPathStore] = [true, false].map((usePreview) =>
       createPathStore(config.clone({ contentful: { usePreview } }))

--- a/packages/graphql-contentful-helpers/src/createSanityLoaders.ts
+++ b/packages/graphql-contentful-helpers/src/createSanityLoaders.ts
@@ -1,0 +1,91 @@
+import DataLoader from 'dataloader';
+import sanityClient, { SanityClient } from '@sanity/client';
+import { ContentfulLoaders, ItemKey, FVLKey, RefByKey } from '@last-rev/types';
+import LastRevAppConfig from '@last-rev/app-config';
+
+const createSanityClient = (config: any, useCdn: boolean): SanityClient => {
+  return sanityClient({
+    projectId: config.projectId,
+    dataset: config.dataset,
+    apiVersion: config.apiVersion || '2021-03-25',
+    token: config.token,
+    useCdn
+  });
+};
+
+const createSanityLoaders = (
+  config: LastRevAppConfig,
+  _defaultLocale: string
+): ContentfulLoaders => {
+  const sanityCfg = (config as any).sanity || {};
+  const prodClient = createSanityClient(sanityCfg, true);
+  const previewClient = createSanityClient(sanityCfg, false);
+
+  const getClient = (preview: boolean) => (preview ? previewClient : prodClient);
+
+  const entryLoader = new DataLoader<ItemKey, any | null>(async (keys) => {
+    const results = await Promise.all(
+      keys.map(({ id, preview }) =>
+        getClient(preview).fetch('*[_id == $id][0]', { id })
+      )
+    );
+    return results;
+  });
+
+  const assetLoader = new DataLoader<ItemKey, any | null>(async (keys) => {
+    const results = await Promise.all(
+      keys.map(({ id, preview }) =>
+        getClient(preview).fetch('*[_id == $id][0]', { id })
+      )
+    );
+    return results;
+  });
+
+  const entriesByContentTypeLoader = new DataLoader<ItemKey, any[]>(async (keys) => {
+    const results = await Promise.all(
+      keys.map(({ id, preview }) =>
+        getClient(preview).fetch('*[_type == $type]', { type: id })
+      )
+    );
+    return results;
+  });
+
+  const entryByFieldValueLoader = new DataLoader<FVLKey, any | null>(async (keys) => {
+    const results = await Promise.all(
+      keys.map(({ contentType, field, value, preview }) =>
+        getClient(preview).fetch(`*[_type == $type && ${field} == $value][0]`, {
+          type: contentType,
+          value
+        })
+      )
+    );
+    return results;
+  });
+
+  const entriesRefByLoader = new DataLoader<RefByKey, any[]>(async (keys) => {
+    const results = await Promise.all(
+      keys.map(({ contentType, field, id, preview }) =>
+        getClient(preview).fetch(`*[_type == $type && references($id)]`, {
+          type: contentType,
+          id
+        })
+      )
+    );
+    return results;
+  });
+
+  const fetchAllContentTypes = async () => {
+    return [];
+  };
+
+  return {
+    entryLoader,
+    assetLoader,
+    entriesByContentTypeLoader,
+    entryByFieldValueLoader,
+    entriesRefByLoader,
+    fetchAllContentTypes
+  };
+};
+
+export default createSanityLoaders;

--- a/packages/graphql-contentful-helpers/src/index.ts
+++ b/packages/graphql-contentful-helpers/src/index.ts
@@ -1,5 +1,6 @@
 import createLoaders from './createLoaders';
+import createSanityLoaders from './createSanityLoaders';
 import createContext from './createContext';
 import contextFunction from './contextFunction';
 
-export { createLoaders, createContext, contextFunction };
+export { createLoaders, createSanityLoaders, createContext, contextFunction };

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -110,6 +110,13 @@ export type ContentfulClients = {
   preview: ContentfulClientApi;
 };
 
+export type CmsClients =
+  | ContentfulClients
+  | {
+      prod: any;
+      preview: any;
+    };
+
 export type PathEntries = (Entry<any> | null)[];
 
 export type PathInfo = {
@@ -136,7 +143,7 @@ export type ApolloContext = {
   path?: string;
   locales: string[];
   preview?: boolean;
-  contentful: ContentfulClients;
+  contentful: CmsClients;
   pathReaders?: PathReaders;
   displayType?: string;
 


### PR DESCRIPTION
## Summary
- support Sanity CMS in createContext
- add Sanity loader factory
- adapt path reader creation for Sanity
- extend types for new cms clients
- export new helpers and dependency

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/... Connect Timeout)*