### PR TITLE
Refactor loader selection

### DIFF
--- a/packages/contentful-cms-loader/src/index.ts
+++ b/packages/contentful-cms-loader/src/index.ts
@@ -3,7 +3,7 @@ import { Entry, Asset, createClient, ContentfulClientApi } from 'contentful';
 import { find, map, partition } from 'lodash';
 import { getWinstonLogger } from '@last-rev/logging';
 import Timer from '@last-rev/timer';
-import { ItemKey, ContentfulLoaders, FVLKey, RefByKey } from '@last-rev/types';
+import { ItemKey, CmsLoaders, FVLKey, RefByKey } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 import { chunk, makeContentfulRequest } from './helpers';
 
@@ -31,7 +31,7 @@ const refByOptions: Options<RefByKey, any, string> = {
 
 const isFulFilled = <T>(p: PromiseSettledResult<T>): p is PromiseFulfilledResult<T> => p.status === 'fulfilled';
 
-const createLoaders = (config: LastRevAppConfig, defaultLocale: string): ContentfulLoaders => {
+const createLoaders = (config: LastRevAppConfig, defaultLocale: string): CmsLoaders => {
   const prodClient = createClient({
     accessToken: config.contentful.contentDeliveryToken,
     space: config.contentful.spaceId,

--- a/packages/contentful-dynamodb-loader/src/index.ts
+++ b/packages/contentful-dynamodb-loader/src/index.ts
@@ -3,7 +3,7 @@ import { Entry, Asset, ContentType } from 'contentful';
 import { transform, omitBy, filter, negate, isEmpty, isError, isNil, map, some } from 'lodash';
 import { getWinstonLogger } from '@last-rev/logging';
 import Timer from '@last-rev/timer';
-import { ItemKey, ContentfulLoaders, FVLKey } from '@last-rev/types';
+import { ItemKey, CmsLoaders, FVLKey } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
 import { DynamoDB, QueryCommandOutput } from '@aws-sdk/client-dynamodb';
@@ -36,7 +36,7 @@ const flvOptions: Options<FVLKey, any, string> = {
   }
 };
 
-const createLoaders = (config: LastRevAppConfig, fallbackLoaders: ContentfulLoaders): ContentfulLoaders => {
+const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): CmsLoaders => {
   const dynamoDB = DynamoDBDocument.from(
     new DynamoDB({
       region: config.dynamodb.region,

--- a/packages/contentful-fs-loader/src/index.ts
+++ b/packages/contentful-fs-loader/src/index.ts
@@ -5,7 +5,7 @@ import { filter, identity, isNil } from 'lodash';
 import { join } from 'path';
 import { getWinstonLogger } from '@last-rev/logging';
 import Timer from '@last-rev/timer';
-import { ItemKey, ContentfulLoaders, FVLKey } from '@last-rev/types';
+import { ItemKey, CmsLoaders, FVLKey } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 
 const logger = getWinstonLogger({
@@ -27,7 +27,7 @@ const flvOptions: Options<FVLKey, any, string> = {
   }
 };
 
-const createLoaders = (config: LastRevAppConfig, fallbackLoaders: ContentfulLoaders): ContentfulLoaders => {
+const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): CmsLoaders => {
   const getUri = (...args: string[]) => {
     return join(config.fs.contentDir, config.contentful.spaceId, config.contentful.env, ...args);
   };

--- a/packages/contentful-path-rules-engine/src/pathToContent/PathToItemsFetcher.ts
+++ b/packages/contentful-path-rules-engine/src/pathToContent/PathToItemsFetcher.ts
@@ -1,5 +1,5 @@
 import { Entry } from 'contentful';
-import { ApolloContext, ContentfulLoaders } from '@last-rev/types';
+import { ApolloContext, CmsLoaders } from '@last-rev/types';
 import RelationShipValidator from '../core/RelationshipValidator';
 import traversePathRule, { PathVisitor } from '../core/traversePathRule';
 import { Field, PathRule, RefByExpression, ReferenceExpression } from '../types';
@@ -31,7 +31,7 @@ export type PathToItemsFetcherContext = {
   slugs: (string | null)[];
   currentSlugIndex: number;
   promises: Promise<FieldValueResult>[];
-  fieldValueLoader: ContentfulLoaders['entryByFieldValueLoader'];
+  fieldValueLoader: CmsLoaders['entryByFieldValueLoader'];
 };
 
 const pathToItemsFetcherVisitor: PathVisitor<PathToItemsFetcherContext> = {

--- a/packages/contentful-redis-loader/src/index.ts
+++ b/packages/contentful-redis-loader/src/index.ts
@@ -3,7 +3,7 @@ import { Entry, Asset, ContentType } from 'contentful';
 import { getWinstonLogger } from '@last-rev/logging';
 import Timer from '@last-rev/timer';
 import Redis from 'ioredis';
-import { ItemKey, ContentfulLoaders, FVLKey } from '@last-rev/types';
+import { ItemKey, CmsLoaders, FVLKey } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 import { getKey, isError, isNil, parse, stringify } from './helpers';
 import { primeRedisEntriesByContentType, primeRedisEntriesOrAssets } from './primers';
@@ -37,7 +37,7 @@ const getClient = (config: LastRevAppConfig) => {
   return clients[key];
 };
 
-const createLoaders = (config: LastRevAppConfig, fallbackLoaders: ContentfulLoaders): ContentfulLoaders => {
+const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): CmsLoaders => {
   const client = getClient(config);
 
   const maxBatchSize = config.redis.maxBatchSize || 1000;

--- a/packages/graphql-contentful-core/src/buildSchema.ts
+++ b/packages/graphql-contentful-core/src/buildSchema.ts
@@ -2,7 +2,7 @@ import { mergeResolvers, mergeTypeDefs } from '@graphql-tools/merge';
 import generateSchema from '@last-rev/graphql-schema-gen';
 import lastRevTypeDefs from './typeDefs';
 import createResolvers from './resolvers/createResolvers';
-import { ContentfulLoaders } from '@last-rev/types';
+import { CmsLoaders } from '@last-rev/types';
 import { GraphQLSchema } from 'graphql';
 
 import { buildSubgraphSchema } from '@apollo/subgraph';
@@ -10,7 +10,7 @@ import { addResolversToSchema, makeExecutableSchema } from '@graphql-tools/schem
 import LastRevAppConfig from '@last-rev/app-config';
 import { createLoaders } from '@last-rev/graphql-contentful-helpers';
 
-const fetchAllContentTypes = async (loaders: ContentfulLoaders) => {
+const fetchAllContentTypes = async (loaders: CmsLoaders) => {
   // may not have production content, if none there, use preview (only needed for filesystem builds)
   const contentTypes = await loaders.fetchAllContentTypes(false);
   if (!contentTypes || !contentTypes.length) {

--- a/packages/graphql-contentful-core/src/resolvers/fieldResolver.test.ts
+++ b/packages/graphql-contentful-core/src/resolvers/fieldResolver.test.ts
@@ -1,4 +1,4 @@
-import { ApolloContext, ContentfulLoaders, Mappers, TypeMapper, TypeMappings } from '@last-rev/types';
+import { ApolloContext, CmsLoaders, Mappers, TypeMapper, TypeMappings } from '@last-rev/types';
 import content from './contentItem.mock';
 import fieldResolver from './fieldResolver';
 import { getWinstonLogger } from '@last-rev/logging';
@@ -20,7 +20,7 @@ const createMockLoader = () => {
 describe('fieldResolver.ts', () => {
   const resolver = fieldResolver('Foo');
   const typeMappings: TypeMappings = {};
-  const loaders: ContentfulLoaders = {
+  const loaders: CmsLoaders = {
     entryLoader: createMockLoader(),
     assetLoader: createMockLoader(),
     entriesByContentTypeLoader: createMockLoader(),

--- a/packages/graphql-contentful-extensions/src/PathsConfigs.ts
+++ b/packages/graphql-contentful-extensions/src/PathsConfigs.ts
@@ -1,5 +1,5 @@
 import { getDefaultFieldValue } from '@last-rev/graphql-contentful-core';
-import { ContentfulLoaders, ContentTypePathRuleConfig, LegacyContentfulPathsConfigs } from '@last-rev/types';
+import { CmsLoaders, ContentTypePathRuleConfig, LegacyContentfulPathsConfigs } from '@last-rev/types';
 import { Entry } from 'contentful';
 import createPath from './utils/createPath';
 
@@ -8,7 +8,7 @@ const BLOGS_LANDING_ID = process.env.BLOGS_LANDING_ID;
 // Path generation
 const validateSite = async (_args: {
   item: Entry<any>;
-  loaders: ContentfulLoaders;
+  loaders: CmsLoaders;
   defaultLocale: string;
   locales: string[];
   preview: boolean;
@@ -41,7 +41,7 @@ const validateSite = async (_args: {
 };
 
 // Used to generate the path for Blog topics and blog posts
-const blogsLandingSlug = async (loaders: ContentfulLoaders, defaultLocale: string, preview?: boolean) => {
+const blogsLandingSlug = async (loaders: CmsLoaders, defaultLocale: string, preview?: boolean) => {
   if (BLOGS_LANDING_ID) {
     const blogsLanding = await loaders.entryLoader.load({ id: BLOGS_LANDING_ID, preview: !!preview });
     if (blogsLanding) {

--- a/packages/graphql-contentful-helpers/src/createLoaders.ts
+++ b/packages/graphql-contentful-helpers/src/createLoaders.ts
@@ -1,15 +1,21 @@
 import createFsLoaders from '@last-rev/contentful-fs-loader';
-import createCmsLoaders from '@last-rev/contentful-cms-loader';
+import createContentfulCmsLoaders from '@last-rev/contentful-cms-loader';
 import createRedisLoaders from '@last-rev/contentful-redis-loader';
 import createDynamoDbLoaders from '@last-rev/contentful-dynamodb-loader';
 
-import { ContentfulLoaders } from '@last-rev/types';
+import { CmsLoaders } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 
-const createLoaders = (config: LastRevAppConfig, defaultLocale: string): ContentfulLoaders => {
+const createLoaders = (config: LastRevAppConfig, defaultLocale: string): CmsLoaders => {
   let loaders;
 
-  const cmsLoaders = createCmsLoaders(config, defaultLocale);
+  let cmsLoaders: CmsLoaders;
+  switch (config.cms) {
+    case 'Contentful':
+    default:
+      cmsLoaders = createContentfulCmsLoaders(config, defaultLocale);
+      break;
+  }
 
   if (config.contentStrategy === 'fs') {
     loaders = createFsLoaders(config, cmsLoaders);

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -38,7 +38,7 @@ export type RefByKey = {
   field: string;
 };
 
-export type ContentfulLoaders = {
+export type CmsLoaders = {
   entryLoader: DataLoader<ItemKey, Entry<any> | null>;
   entriesRefByLoader: DataLoader<RefByKey, Entry<any>[]>;
   entryByFieldValueLoader: DataLoader<FVLKey, Entry<any> | null>;
@@ -54,7 +54,7 @@ export type TypeMappings = {
 
 export type ContentfulPathsGenerator = (
   resolvedItem: Entry<any>,
-  loaders: ContentfulLoaders,
+  loaders: CmsLoaders,
   defaultLocale: string,
   locales: string[],
   preview?: boolean,
@@ -126,7 +126,7 @@ export type LoadEntriesForPathFunction = (
 export type loadPathsForContentFunction = (entry: Entry<any>, ctx: ApolloContext, site?: string) => Promise<PathInfo[]>;
 
 export type ApolloContext = {
-  loaders: ContentfulLoaders;
+  loaders: CmsLoaders;
   mappers: Mappers;
   defaultLocale: string;
   typeMappings: TypeMappings;


### PR DESCRIPTION
## Summary
- rename `ContentfulLoaders` type to `CmsLoaders`
- select CMS loaders in `createLoaders` using `config.cms`
- update all packages to use `CmsLoaders`

## Testing
- `yarn test` *(fails: Connect Timeout Error)*