### PR TITLE
Add Sanity schemas matching Contentful models

### DIFF
--- a/sanity/README.md
+++ b/sanity/README.md
@@ -1,0 +1,35 @@
+# Sanity Schemas for LastRev Libraries
+
+This folder contains Sanity schema definitions that mirror the Contentful models used in this repository. The document and field names match the Contentful IDs so existing GraphQL extensions can operate without modification.
+
+## Setup
+
+1. Install the Sanity CLI globally if you haven't already:
+   ```bash
+   npm install -g sanity
+   ```
+2. Create a new Sanity project inside this repository (or elsewhere):
+   ```bash
+   sanity init --create-project "my-project"
+   ```
+3. Copy the `sanity/schemas` folder into your Sanity studio and update the `sanity.config.ts` (or `sanity.json` for older studios) to load the schema types:
+   ```ts
+   import { defineConfig } from 'sanity'
+   import schemaTypes from './schemas'
+
+   export default defineConfig({
+     schema: {
+       types: schemaTypes
+     }
+   })
+   ```
+4. Run the studio:
+   ```bash
+   sanity start
+   ```
+
+## Migrating Content
+
+Content can be exported from Contentful using the [`contentful-export`](https://github.com/contentful/contentful-export) tool. The resulting data can be transformed and imported into Sanity using [`@sanity/import`](https://www.sanity.io/docs/importing-data).
+
+Make sure slugs and reference IDs are preserved during the migration so the GraphQL layer continues to resolve paths correctly.

--- a/sanity/schemas/blog.ts
+++ b/sanity/schemas/blog.ts
@@ -1,0 +1,23 @@
+export default {
+  name: 'blog',
+  title: 'Blog',
+  type: 'document',
+  fields: [
+    { name: 'title', type: 'string' },
+    { name: 'slug', type: 'slug', options: { source: 'title', maxLength: 96 } },
+    { name: 'author', type: 'reference', to: [{ type: 'person' }] },
+    { name: 'body', type: 'richText' },
+    { name: 'categories', type: 'array', of: [{ type: 'reference', to: [{ type: 'categoryBlog' }] }] },
+    { name: 'contents', type: 'array', of: [{ type: 'reference', to: [{ type: 'content' }] }] },
+    { name: 'disableBackToTop', type: 'boolean' },
+    { name: 'featuredMedia', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'footer', type: 'reference', to: [{ type: 'content' }] },
+    { name: 'header', type: 'reference', to: [{ type: 'header' }] },
+    { name: 'pubDate', type: 'datetime' },
+    { name: 'relatedLinks', type: 'array', of: [{ type: 'reference', to: [{ type: 'link' }] }] },
+    { name: 'seo', type: 'object', fields: [] },
+    { name: 'summary', type: 'text' },
+    { name: 'tags', type: 'array', of: [{ type: 'string' }] },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/card.ts
+++ b/sanity/schemas/card.ts
@@ -1,0 +1,16 @@
+export default {
+  name: 'card',
+  title: 'Card',
+  type: 'document',
+  fields: [
+    { name: 'title', type: 'string' },
+    { name: 'subtitle', type: 'string' },
+    { name: 'internalTitle', type: 'string' },
+    { name: 'body', type: 'richText' },
+    { name: 'media', type: 'array', of: [{ type: 'reference', to: [{ type: 'media' }] }] },
+    { name: 'actions', type: 'array', of: [{ type: 'reference', to: [{ type: 'link' }] }] },
+    { name: 'link', type: 'reference', to: [{ type: 'link' }] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/categoryBlog.ts
+++ b/sanity/schemas/categoryBlog.ts
@@ -1,0 +1,15 @@
+export default {
+  name: 'categoryBlog',
+  title: 'Category Blog',
+  type: 'document',
+  fields: [
+    { name: 'title', type: 'string' },
+    { name: 'slug', type: 'slug', options: { source: 'title', maxLength: 96 } },
+    { name: 'header', type: 'reference', to: [{ type: 'header' }] },
+    { name: 'footer', type: 'reference', to: [{ type: 'content' }] },
+    { name: 'hero', type: 'reference', to: [{ type: 'hero' }] },
+    { name: 'contents', type: 'array', of: [{ type: 'reference', to: [{ type: 'content' }] }] },
+    { name: 'seo', type: 'object', fields: [] },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/collection.ts
+++ b/sanity/schemas/collection.ts
@@ -1,0 +1,19 @@
+export default {
+  name: 'collection',
+  title: 'Collection',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'introText', type: 'reference', to: [{ type: 'text' }] },
+    { name: 'items', type: 'array', of: [
+        { type: 'reference', to: [{ type: 'card' }, { type: 'link' }, { type: 'media' }, { type: 'navigationItem' }, { type: 'section' }] }
+      ] },
+    { name: 'itemsSpacing', type: 'number' },
+    { name: 'itemsVariant', type: 'string' },
+    { name: 'itemsWidth', type: 'string' },
+    { name: 'settings', type: 'object', fields: [] },
+    { name: 'styles', type: 'object', fields: [] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/content.ts
+++ b/sanity/schemas/content.ts
@@ -1,0 +1,21 @@
+export default {
+  name: 'content',
+  title: 'Content',
+  type: 'reference',
+  to: [
+    { type: 'blog' },
+    { type: 'card' },
+    { type: 'categoryBlog' },
+    { type: 'collection' },
+    { type: 'header' },
+    { type: 'hero' },
+    { type: 'link' },
+    { type: 'media' },
+    { type: 'navigationItem' },
+    { type: 'page' },
+    { type: 'person' },
+    { type: 'quote' },
+    { type: 'section' },
+    { type: 'text' }
+  ]
+}

--- a/sanity/schemas/header.ts
+++ b/sanity/schemas/header.ts
@@ -1,0 +1,15 @@
+export default {
+  name: 'header',
+  title: 'Header',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'color', type: 'string' },
+    { name: 'colorScheme', type: 'string' },
+    { name: 'logo', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'logoUrl', type: 'url' },
+    { name: 'navigationItems', type: 'array', of: [{ type: 'reference', to: [{ type: 'collection' }] }] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/hero.ts
+++ b/sanity/schemas/hero.ts
@@ -1,0 +1,21 @@
+export default {
+  name: 'hero',
+  title: 'Hero',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'title', type: 'string' },
+    { name: 'subtitle', type: 'string' },
+    { name: 'overline', type: 'string' },
+    { name: 'body', type: 'richText' },
+    { name: 'image', type: 'array', of: [{ type: 'reference', to: [{ type: 'media' }] }] },
+    { name: 'background', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'backgroundAsset', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'backgroundColor', type: 'string' },
+    { name: 'contentHeight', type: 'string' },
+    { name: 'contentWidth', type: 'string' },
+    { name: 'actions', type: 'array', of: [{ type: 'reference', to: [{ type: 'link' }] }] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,0 +1,37 @@
+export { default as blog } from './blog'
+export { default as page } from './page'
+export { default as categoryBlog } from './categoryBlog'
+export { default as card } from './card'
+export { default as collection } from './collection'
+export { default as header } from './header'
+export { default as hero } from './hero'
+export { default as link } from './link'
+export { default as media } from './media'
+export { default as navigationItem } from './navigationItem'
+export { default as person } from './person'
+export { default as quote } from './quote'
+export { default as section } from './section'
+export { default as text } from './text'
+export { default as theme } from './theme'
+export { default as richText } from './richText'
+export { default as content } from './content'
+
+export default [
+  blog,
+  page,
+  categoryBlog,
+  card,
+  collection,
+  header,
+  hero,
+  link,
+  media,
+  navigationItem,
+  person,
+  quote,
+  section,
+  text,
+  theme,
+  richText,
+  content
+]

--- a/sanity/schemas/link.ts
+++ b/sanity/schemas/link.ts
@@ -1,0 +1,15 @@
+export default {
+  name: 'link',
+  title: 'Link',
+  type: 'document',
+  fields: [
+    { name: 'text', type: 'string' },
+    { name: 'href', type: 'url' },
+    { name: 'manualUrl', type: 'url' },
+    { name: 'icon', type: 'string' },
+    { name: 'iconPosition', type: 'string' },
+    { name: 'color', type: 'string' },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/media.ts
+++ b/sanity/schemas/media.ts
@@ -1,0 +1,19 @@
+export default {
+  name: 'media',
+  title: 'Media',
+  type: 'document',
+  fields: [
+    { name: 'title', type: 'string' },
+    { name: 'description', type: 'text' },
+    { name: 'assetURL', type: 'url' },
+    { name: 'file', type: 'file' },
+    { name: 'fileMobile', type: 'file' },
+    { name: 'fileTablet', type: 'file' },
+    { name: 'mobile', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'tablet', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'placeholder', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'source', type: 'string' },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/navigationItem.ts
+++ b/sanity/schemas/navigationItem.ts
@@ -1,0 +1,17 @@
+export default {
+  name: 'navigationItem',
+  title: 'Navigation Item',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'text', type: 'string' },
+    { name: 'summary', type: 'text' },
+    { name: 'href', type: 'url' },
+    { name: 'manualUrl', type: 'url' },
+    { name: 'image', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'media', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'subNavigation', type: 'array', of: [{ type: 'reference', to: [{ type: 'navigationItem' }, { type: 'link' }] }] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/page.ts
+++ b/sanity/schemas/page.ts
@@ -1,0 +1,18 @@
+export default {
+  name: 'page',
+  title: 'Page',
+  type: 'document',
+  fields: [
+    { name: 'title', type: 'string' },
+    { name: 'slug', type: 'slug', options: { source: 'title', maxLength: 96 } },
+    { name: 'internalTitle', type: 'string' },
+    { name: 'colorScheme', type: 'string' },
+    { name: 'hero', type: 'reference', to: [{ type: 'hero' }] },
+    { name: 'contents', type: 'array', of: [{ type: 'reference', to: [{ type: 'content' }] }] },
+    { name: 'disableBackToTop', type: 'boolean' },
+    { name: 'footer', type: 'reference', to: [{ type: 'content' }] },
+    { name: 'header', type: 'reference', to: [{ type: 'header' }] },
+    { name: 'seo', type: 'object', fields: [] },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/person.ts
+++ b/sanity/schemas/person.ts
@@ -1,0 +1,12 @@
+export default {
+  name: 'person',
+  title: 'Person',
+  type: 'document',
+  fields: [
+    { name: 'name', type: 'string' },
+    { name: 'jobTitle', type: 'string' },
+    { name: 'image', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/quote.ts
+++ b/sanity/schemas/quote.ts
@@ -1,0 +1,14 @@
+export default {
+  name: 'quote',
+  title: 'Quote',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'quote', type: 'text' },
+    { name: 'authorName', type: 'string' },
+    { name: 'authorTitle', type: 'string' },
+    { name: 'image', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/richText.ts
+++ b/sanity/schemas/richText.ts
@@ -1,0 +1,6 @@
+export default {
+  name: 'richText',
+  title: 'Rich Text',
+  type: 'array',
+  of: [{ type: 'block' }]
+}

--- a/sanity/schemas/section.ts
+++ b/sanity/schemas/section.ts
@@ -1,0 +1,23 @@
+export default {
+  name: 'section',
+  title: 'Section',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'contents', type: 'array', of: [{ type: 'reference', to: [{ type: 'content' }] }] },
+    { name: 'background', type: 'reference', to: [{ type: 'media' }] },
+    { name: 'backgroundColor', type: 'string' },
+    { name: 'contentAlignment', type: 'string' },
+    { name: 'contentDirection', type: 'string' },
+    { name: 'contentSpacing', type: 'number' },
+    { name: 'contentWidth', type: 'string' },
+    { name: 'paddingTop', type: 'number' },
+    { name: 'paddingBottom', type: 'number' },
+    { name: 'paddingLeft', type: 'number' },
+    { name: 'paddingRight', type: 'number' },
+    { name: 'styles', type: 'object', fields: [] },
+    { name: 'settings', type: 'object', fields: [] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/text.ts
+++ b/sanity/schemas/text.ts
@@ -1,0 +1,14 @@
+export default {
+  name: 'text',
+  title: 'Text',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'body', type: 'richText' },
+    { name: 'color', type: 'string' },
+    { name: 'align', type: 'string' },
+    { name: 'styles', type: 'object', fields: [] },
+    { name: 'variant', type: 'string' },
+    { name: 'theme', type: 'array', of: [{ type: 'reference', to: [{ type: 'theme' }] }] }
+  ]
+}

--- a/sanity/schemas/theme.ts
+++ b/sanity/schemas/theme.ts
@@ -1,0 +1,12 @@
+export default {
+  name: 'theme',
+  title: 'Theme',
+  type: 'document',
+  fields: [
+    { name: 'internalTitle', type: 'string' },
+    { name: 'description', type: 'text' },
+    { name: 'components', type: 'object', fields: [] },
+    { name: 'typography', type: 'object', fields: [] },
+    { name: 'variant', type: 'string' }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a `sanity` folder containing schemas that mirror the Contentful models
- include setup instructions for starting a Sanity studio with these schemas

## Testing
- `yarn test` *(fails: unable to download Yarn package)*