### PR TITLE
Add Sanity doc conversion helper

### DIFF
--- a/packages/sanity-cms-loader/README.md
+++ b/packages/sanity-cms-loader/README.md
@@ -22,6 +22,19 @@ async function () {
 
 `entryLoader`, `assetLoader`, and `entriesByContentTypeLoader` are all instances of [dataloader](https://github.com/graphql/dataloader). `entryLoader` and `assetLoader` are both keyed by Sanity ID (`string`), and `entriesByContentTypeLoader` is keyed by a Sanity content type ID (`string`).
 
+Each returned document is converted to the following shape:
+
+```ts
+{
+  sys: {
+    id: '<sanity id>',
+    updatedAt: '<sanity updatedAt>',
+    contentType: { sys: { id: '<sanity _type>' } }
+  },
+  fields: { /* original document fields */ }
+}
+```
+
 ```Javascript
 const myEntry = await entryLoader('my-content-id-1234');
 const myAsset = await assetLoader('my-asset-id-5432');

--- a/packages/sanity-cms-loader/src/index.ts
+++ b/packages/sanity-cms-loader/src/index.ts
@@ -6,6 +6,15 @@ import Timer from '@last-rev/timer';
 import { ItemKey, ContentfulLoaders, FVLKey, RefByKey } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 
+const convertSanityDoc = (doc: any) => {
+  if (!doc) return null;
+  const { _id, _type, _updatedAt, ...fields } = doc;
+  return {
+    sys: { id: _id, updatedAt: _updatedAt, contentType: { sys: { id: _type } } },
+    fields
+  };
+};
+
 const logger = getWinstonLogger({ package: 'sanity-cms-loader', module: 'index', strategy: 'Cms' });
 
 const options: Options<ItemKey, any, string> = {
@@ -61,7 +70,7 @@ const createLoaders = (config: LastRevAppConfig): ContentfulLoaders => {
         fetchBatchItems(map(prodKeys, 'id'), prodClient)
       ]);
       const all = [...previewDocs, ...prodDocs];
-      const items = keys.map(({ id }) => all.find((d) => d && d._id === id) || null);
+      const items = keys.map(({ id }) => convertSanityDoc(all.find((d) => d && d._id === id)));
       logger.debug('Fetched docs', {
         caller: 'getBatchItemFetcher',
         elapsedMs: timer.end().millis,
@@ -80,7 +89,7 @@ const createLoaders = (config: LastRevAppConfig): ContentfulLoaders => {
           const client = preview ? previewClient : prodClient;
           const query = '*[_type == $type]';
           const docs = await client.fetch(query, { type: id });
-          return docs as any[];
+          return docs.map(convertSanityDoc) as any[];
         })
       );
       logger.debug('Fetched docs by type', {
@@ -101,7 +110,7 @@ const createLoaders = (config: LastRevAppConfig): ContentfulLoaders => {
           const client = preview ? previewClient : prodClient;
           const query = `*[_type == $type && ${field} == $value][0]`;
           const doc = await client.fetch(query, { type: contentType, value });
-          return doc || null;
+          return convertSanityDoc(doc);
         })
       );
       logger.debug('Fetched doc by field value', {
@@ -122,7 +131,7 @@ const createLoaders = (config: LastRevAppConfig): ContentfulLoaders => {
           const client = preview ? previewClient : prodClient;
           const query = `*[_type == $type && (${field}._ref == $id || $id in ${field}[]._ref)]`;
           const docs = await client.fetch(query, { type: contentType, id });
-          return docs as any[];
+          return docs.map(convertSanityDoc) as any[];
         })
       );
       logger.debug('Fetched docs ref by', {


### PR DESCRIPTION
## Summary
- convert Sanity docs to a CMS-style structure
- update loaders to return converted documents
- document the returned shape

## Testing
- `yarn workspace @last-rev/sanity-cms-loader test` *(fails: connect EHOSTUNREACH)*
- `yarn workspace @last-rev/sanity-cms-loader build` *(fails: connect EHOSTUNREACH)*