### PR TITLE
Update schema cache key

### DIFF
--- a/packages/graphql-contentful-core/src/SchemaCache.ts
+++ b/packages/graphql-contentful-core/src/SchemaCache.ts
@@ -16,7 +16,13 @@ export default class SchemaCache {
   };
 
   public getSchema = async (config: LastRevAppConfig) => {
-    const key = JSON.stringify([config.contentful.spaceId, config.contentful.env]);
+    const keyParts = [config.cms];
+    if (config.cms === 'Sanity') {
+      keyParts.push(config.sanity.projectId, config.sanity.dataset);
+    } else {
+      keyParts.push(config.contentful.spaceId, config.contentful.env);
+    }
+    const key = JSON.stringify(keyParts);
     if (!this.schemaMap[key]) {
       this.schemaMap[key] = await buildSchema(config);
     }


### PR DESCRIPTION
## Summary
- update SchemaCache cache key to include CMS name
- add Sanity project and dataset to key when using Sanity

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz)*
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz)*