### PR TITLE
Document Sanity path limitation

### DIFF
--- a/packages/graphql-contentful-core/README.md
+++ b/packages/graphql-contentful-core/README.md
@@ -175,6 +175,8 @@ const mappers = {
 
 PathsConfigs allow you to define how a path is constructed from a specific content type. There are two ways to define these:
 
+**Important:** When using Sanity as the CMS, path resolution is not currently supported. Any queries relying on path readers will return no results.
+
 1. A mapping from a contentType name to a string representing the root of the path. This will append the `slug` field of the content item to the root in order to construct the path for a specific content item:
 
 ```javascript

--- a/packages/graphql-contentful-helpers/src/createPathReaders.ts
+++ b/packages/graphql-contentful-helpers/src/createPathReaders.ts
@@ -4,6 +4,7 @@ import LastRevAppConfig from '@last-rev/app-config';
 
 const createPathReaders = (config: LastRevAppConfig): PathReaders | undefined => {
   if (config.cms === 'Sanity') {
+    console.warn('Path resolution is not supported when using Sanity CMS.');
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- warn when using Sanity in `createPathReaders`
- document that path resolution isn't supported with Sanity

## Testing
- `yarn test` *(fails: Connect Timeout Error)*