### PR TITLE
Fix Sanity loader changelog header

### DIFF
--- a/packages/sanity-cms-loader/CHANGELOG.md
+++ b/packages/sanity-cms-loader/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @last-rev/contentful-cms-loader
+# @last-rev/sanity-cms-loader
 
 ## 0.5.0
 


### PR DESCRIPTION
## Summary
- correct package heading in `packages/sanity-cms-loader/CHANGELOG.md`

## Testing
- `yarn test` *(fails: Unable to download dependencies)*