### PR TITLE
Add Sanity loader support

### DIFF
--- a/packages/graphql-contentful-core/src/SchemaCache.ts
+++ b/packages/graphql-contentful-core/src/SchemaCache.ts
@@ -16,7 +16,10 @@ export default class SchemaCache {
   };
 
   public getSchema = async (config: LastRevAppConfig) => {
-    const key = JSON.stringify([config.contentful.spaceId, config.contentful.env]);
+    const key =
+      config.cms === 'Sanity'
+        ? JSON.stringify([config.sanity.projectId, config.sanity.dataset])
+        : JSON.stringify([config.contentful.spaceId, config.contentful.env]);
     if (!this.schemaMap[key]) {
       this.schemaMap[key] = await buildSchema(config);
     }

--- a/packages/graphql-contentful-core/src/buildSchema.ts
+++ b/packages/graphql-contentful-core/src/buildSchema.ts
@@ -8,7 +8,7 @@ import { GraphQLSchema } from 'graphql';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { addResolversToSchema, makeExecutableSchema } from '@graphql-tools/schema';
 import LastRevAppConfig from '@last-rev/app-config';
-import { createLoaders } from '@last-rev/graphql-contentful-helpers';
+import { createLoaders, createSanityLoaders } from '@last-rev/graphql-contentful-helpers';
 
 const fetchAllContentTypes = async (loaders: CmsLoaders) => {
   // may not have production content, if none there, use preview (only needed for filesystem builds)
@@ -21,7 +21,8 @@ const fetchAllContentTypes = async (loaders: CmsLoaders) => {
 
 const buildSchema = async (config: LastRevAppConfig): Promise<GraphQLSchema> => {
   // locale doesn't matter for this use case
-  const loaders = createLoaders(config, 'en-US');
+  const loaders =
+    config.cms === 'Sanity' ? createSanityLoaders(config, 'en-US') : createLoaders(config, 'en-US');
   const contentTypes = await fetchAllContentTypes(loaders);
 
   const baseTypeDefs = await generateSchema({


### PR DESCRIPTION
## Summary
- handle `cms` in `buildSchema` to choose proper loader
- cache schema using Sanity identifiers
- fetch Sanity content types from local schema files or API

## Testing
- `yarn test` *(fails: unable to download dependencies)*