### PR TITLE
Add Sanity webhook handler package

### DIFF
--- a/examples/lastrev-next-starter/packages/functions/package.json
+++ b/examples/lastrev-next-starter/packages/functions/package.json
@@ -5,6 +5,7 @@
   "scripts": {},
   "dependencies": {
     "@last-rev/contentful-webhook-handler": "^0.4.11",
+    "@last-rev/sanity-webhook-handler": "^0.1.0",
     "@last-rev/graphql-algolia-integration": "^0.1.10",
     "@last-rev/graphql-contentful-core": "^0.5.14",
     "@lrns/graphql-extensions": "^0.1.0",

--- a/examples/lastrev-next-starter/packages/functions/src/contentful-webhook/contentful-webhook.js
+++ b/examples/lastrev-next-starter/packages/functions/src/contentful-webhook/contentful-webhook.js
@@ -1,7 +1,14 @@
 require('dotenv').config();
 
-const handleWebhook = require('@last-rev/contentful-webhook-handler');
 const config = require('../../../../config');
+
+let handleWebhook;
+
+if (process.env.CMS === 'Sanity') {
+  handleWebhook = require('@last-rev/sanity-webhook-handler');
+} else {
+  handleWebhook = require('@last-rev/contentful-webhook-handler');
+}
 
 module.exports.handler = async (event) => {
   try {

--- a/packages/sanity-webhook-handler/CHANGELOG.md
+++ b/packages/sanity-webhook-handler/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @last-rev/sanity-webhook-handler
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial implementation mirroring the contentful-webhook-handler

--- a/packages/sanity-webhook-handler/jest.config.js
+++ b/packages/sanity-webhook-handler/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@last-rev/testing-library').config();

--- a/packages/sanity-webhook-handler/package.json
+++ b/packages/sanity-webhook-handler/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@last-rev/sanity-webhook-handler",
+  "version": "0.1.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "run-s clean build:prod",
+    "dev": "cross-env NODE_ENV=development rollup -cw",
+    "build:prod": "cross-env NODE_ENV=production rollup -c",
+    "lint": "tslint --project tsconfig.json",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch"
+  },
+  "devDependencies": {
+    "@last-rev/app-config": "^0.5.0",
+    "@last-rev/rollup-config": "^0.1.4",
+    "@last-rev/testing-library": "^0.1.10",
+    "jest": "^26.6.3"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.303.0",
+    "@aws-sdk/lib-dynamodb": "^3.303.0",
+    "@last-rev/graphql-contentful-helpers": "^0.5.0",
+    "@sanity/client": "^5.8.0",
+    "ioredis": "^5.0.4",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/sanity-webhook-handler/rollup.config.js
+++ b/packages/sanity-webhook-handler/rollup.config.js
@@ -1,0 +1,6 @@
+import { config } from '@last-rev/rollup-config';
+
+export default config({
+  input: './src/index.ts',
+  babelHelpers: 'runtime'
+});

--- a/packages/sanity-webhook-handler/src/constants.ts
+++ b/packages/sanity-webhook-handler/src/constants.ts
@@ -1,0 +1,1 @@
+export const LOG_PREFIX = '[sanity-webhook-handler]';

--- a/packages/sanity-webhook-handler/src/dynamodbHandlers.ts
+++ b/packages/sanity-webhook-handler/src/dynamodbHandlers.ts
@@ -1,0 +1,56 @@
+import LastRevAppConfig from '@last-rev/app-config';
+import { Handlers } from './types';
+import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
+import { DynamoDB } from '@aws-sdk/client-dynamodb';
+import { createContext } from '@last-rev/graphql-contentful-helpers';
+import { updateAllPaths } from '@last-rev/contentful-path-util';
+
+export const createDynamoDbHandlers = (config: LastRevAppConfig): Handlers => {
+  const pk = () => `${config.sanity.projectId}:${config.sanity.dataset}`;
+
+  const dynamoDB = DynamoDBDocument.from(
+    new DynamoDB({
+      region: config.dynamodb.region,
+      credentials: {
+        accessKeyId: config.dynamodb.accessKeyId,
+        secretAccessKey: config.dynamodb.secretAccessKey
+      }
+    })
+  );
+
+  const putData = async (data: any, sk: string) => {
+    await dynamoDB.put({
+      TableName: config.dynamodb.tableName,
+      Item: {
+        pk: pk(),
+        sk,
+        data
+      }
+    });
+  };
+
+  const delData = async (sk: string) => {
+    await dynamoDB.delete({
+      TableName: config.dynamodb.tableName,
+      Key: { pk: pk(), sk }
+    });
+  };
+
+  return {
+    entry: async (command) => {
+      const { data } = command;
+      const sk = `entries:${data._id}`;
+      if (command.action === 'update') {
+        await putData(data, sk);
+      } else if (command.action === 'delete') {
+        await delData(sk);
+      }
+    },
+    asset: async () => {},
+    contentType: async () => {},
+    paths: async (updateForPreview, updateForProd) => {
+      const context = await createContext({ config });
+      await updateAllPaths({ config, updateForPreview, updateForProd, context });
+    }
+  };
+};

--- a/packages/sanity-webhook-handler/src/handlers.ts
+++ b/packages/sanity-webhook-handler/src/handlers.ts
@@ -1,0 +1,17 @@
+import LastRevAppConfig from '@last-rev/app-config';
+import { Handlers } from './types';
+import { createRedisHandlers } from './redisHandlers';
+import { createDynamoDbHandlers } from './dynamodbHandlers';
+
+export const createHandlers = (config: LastRevAppConfig): Handlers => {
+  switch (config.cmsCacheStrategy) {
+    case 'redis':
+      return createRedisHandlers(config);
+    case 'dynamodb':
+      return createDynamoDbHandlers(config);
+    case 'none':
+      throw new Error('cmsCacheStrategy "none" does not need a webhook handler');
+    default:
+      throw new Error(`Unknown or unsuported cmsCacheStrategy ${config.cmsCacheStrategy}`);
+  }
+};

--- a/packages/sanity-webhook-handler/src/helpers.ts
+++ b/packages/sanity-webhook-handler/src/helpers.ts
@@ -1,0 +1,7 @@
+export const stringify = (r: any): string | undefined => {
+  try {
+    return JSON.stringify(r);
+  } catch (_e) {
+    return undefined;
+  }
+};

--- a/packages/sanity-webhook-handler/src/index.ts
+++ b/packages/sanity-webhook-handler/src/index.ts
@@ -1,0 +1,56 @@
+import { createClient } from '@sanity/client';
+import { map } from 'lodash';
+import LastRevAppConfig from '@last-rev/app-config';
+import { ProcessCommand } from './types';
+import { createHandlers } from './handlers';
+import { getWinstonLogger } from '@last-rev/logging';
+
+const logger = getWinstonLogger({
+  package: 'sanity-webhook-handler',
+  module: 'index'
+});
+
+type WebhookIds = { created?: string[]; updated?: string[]; deleted?: string[] };
+
+type WebhookBody = { ids?: WebhookIds };
+
+const handleWebhook = async (config: LastRevAppConfig, body: WebhookBody) => {
+  const sanityCfg = (config as any).sanity || {};
+
+  const client = createClient({
+    projectId: sanityCfg.projectId,
+    dataset: sanityCfg.dataset,
+    apiVersion: sanityCfg.apiVersion || '2021-10-21',
+    token: sanityCfg.token,
+    useCdn: false
+  });
+
+  const handlers = createHandlers(config);
+
+  const processDoc = async (id: string, action: 'update' | 'delete') => {
+    try {
+      let data: any = { _id: id };
+      if (action === 'update') {
+        const doc = await client.getDocument(id);
+        if (!doc) return;
+        data = doc;
+      }
+      await handlers.entry({ isPreview: false, action, data } as ProcessCommand<any>);
+    } catch (err: any) {
+      logger.error(`Error processing document ${id}: ${err.message}`, { caller: 'handleWebhook', stack: err.stack });
+    }
+  };
+
+  const ids = body.ids || {};
+  await Promise.all(
+    [
+      ...(ids.created || []).map((id) => processDoc(id, 'update')),
+      ...(ids.updated || []).map((id) => processDoc(id, 'update')),
+      ...(ids.deleted || []).map((id) => processDoc(id, 'delete'))
+    ]
+  );
+
+  await handlers.paths(true, true);
+};
+
+export default handleWebhook;

--- a/packages/sanity-webhook-handler/src/redisHandlers.ts
+++ b/packages/sanity-webhook-handler/src/redisHandlers.ts
@@ -1,0 +1,43 @@
+import LastRevAppConfig from '@last-rev/app-config';
+import { Handlers } from './types';
+import Redis from 'ioredis';
+import { stringify } from './helpers';
+import { createContext } from '@last-rev/graphql-contentful-helpers';
+import { updateAllPaths } from '@last-rev/contentful-path-util';
+
+const clients: Record<string, Redis> = {};
+
+const getClient = (config: LastRevAppConfig) => {
+  const key = JSON.stringify([config.redis, config.sanity.projectId, config.sanity.dataset]);
+  if (!clients[key]) {
+    clients[key] = new Redis({
+      ...config.redis,
+      keyPrefix: `${config.sanity.projectId}:${config.sanity.dataset}:`
+    });
+  }
+  return clients[key];
+};
+
+export const createRedisHandlers = (config: LastRevAppConfig): Handlers => {
+  const redis = getClient(config);
+  const { ttlSeconds } = config.redis;
+
+  return {
+    entry: async (command) => {
+      const { data } = command;
+      const key = `production:entries:${data._id}`;
+      if (command.action === 'update') {
+        const val = stringify(data);
+        if (val) await redis.set(key, val, 'EX', ttlSeconds);
+      } else if (command.action === 'delete') {
+        await redis.del(key);
+      }
+    },
+    asset: async () => {},
+    contentType: async () => {},
+    paths: async (updateForPreview, updateForProd) => {
+      const context = await createContext({ config });
+      await updateAllPaths({ config, updateForPreview, updateForProd, context });
+    }
+  };
+};

--- a/packages/sanity-webhook-handler/src/types.ts
+++ b/packages/sanity-webhook-handler/src/types.ts
@@ -1,0 +1,12 @@
+export type ProcessCommand<T> = {
+  isPreview: boolean;
+  action: 'update' | 'delete';
+  data: T;
+};
+
+export type Handlers = {
+  entry: (data: ProcessCommand<any>) => Promise<void>;
+  asset: (data: ProcessCommand<any>) => Promise<void>;
+  contentType: (data: ProcessCommand<any>) => Promise<void>;
+  paths: (applyToPreview: boolean, applyToProduction: boolean) => Promise<void>;
+};

--- a/packages/sanity-webhook-handler/tsconfig.json
+++ b/packages/sanity-webhook-handler/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist",
+    "declarationDir": "dist",
+    "module": "esnext",
+    "target": "es5",
+    "lib": ["es6", "dom", "es2016", "es2017"],
+    "jsx": "react",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- create `sanity-webhook-handler` package modeled on the contentful handler
- use Sanity handler when CMS env var indicates Sanity in Netlify function
- expose new handler in functions package dependencies

## Testing
- `yarn test` *(fails: could not download Yarn)*