### PR TITLE
Introduce CmsEntry and CmsAsset types

### DIFF
--- a/packages/contentful-cms-loader/src/helpers.ts
+++ b/packages/contentful-cms-loader/src/helpers.ts
@@ -1,8 +1,9 @@
-import { Asset, ContentfulClientApi, Entry } from 'contentful';
+import { ContentfulClientApi } from 'contentful';
+import { CmsEntry, CmsAsset } from '@last-rev/types';
 
 export const isRejected = (r: PromiseSettledResult<unknown>): r is PromiseRejectedResult => r.status === 'rejected';
 
-export const makeContentfulRequest = async <T extends Entry<any> | Asset>(
+export const makeContentfulRequest = async <T extends CmsEntry<any> | CmsAsset<any>>(
   client: ContentfulClientApi,
   command: 'getEntries' | 'getAssets',
   limit: number,

--- a/packages/contentful-dynamodb-loader/src/index.ts
+++ b/packages/contentful-dynamodb-loader/src/index.ts
@@ -1,5 +1,6 @@
 import DataLoader, { Options } from 'dataloader';
-import { Entry, Asset, ContentType } from 'contentful';
+import { ContentType } from 'contentful';
+import { CmsEntry, CmsAsset } from '@last-rev/types';
 import { transform, omitBy, filter, negate, isEmpty, isError, isNil, map, some } from 'lodash';
 import { getWinstonLogger } from '@last-rev/logging';
 import Timer from '@last-rev/timer';
@@ -74,7 +75,7 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
   ): Promise<(T | null)[]> => {
     let timer = new Timer();
 
-    const results: (Entry<any> | Asset)[] = map(
+    const results: (CmsEntry<any> | CmsAsset<any>)[] = map(
       await Promise.all(
         keys.map(({ preview, id }) =>
           dynamoDB.get({
@@ -105,7 +106,7 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
       timer = new Timer();
       const sourceResults = filter(await fallbackLoader.loadMany(cacheMissIds), (r) => {
         return r && !isError(r);
-      }) as unknown as (Entry<any> | Asset)[];
+      }) as unknown as (CmsEntry<any> | CmsAsset<any>)[];
 
       keyedResults = {
         ...keyedResults,
@@ -140,7 +141,7 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
   };
 
   const getBatchItemFetcher =
-    <T extends Entry<any> | Asset>(dirname: 'entries' | 'assets'): DataLoader.BatchLoadFn<ItemKey, T | null> =>
+    <T extends CmsEntry<any> | CmsAsset<any>>(dirname: 'entries' | 'assets'): DataLoader.BatchLoadFn<ItemKey, T | null> =>
     async (keys) =>
       fetchAndSet<T>(
         keys,
@@ -148,7 +149,7 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
         dirname
       );
 
-  const getBatchEntriesByContentTypeFetcher = (): DataLoader.BatchLoadFn<ItemKey, Entry<any>[]> => async (keys) => {
+  const getBatchEntriesByContentTypeFetcher = (): DataLoader.BatchLoadFn<ItemKey, CmsEntry<any>[]> => async (keys) => {
     let timer = new Timer();
 
     if (!keys.length) return [];
@@ -171,7 +172,7 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
           IndexName: 'pkTypeIndex'
         }
       });
-      const entries = map(itemList, 'data') as unknown as Entry<any>[];
+      const entries = map(itemList, 'data') as unknown as CmsEntry<any>[];
       return {
         entries,
         key
@@ -188,7 +189,7 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
       (accum, v) => {
         accum[`${v.key.id}::${v.key.preview}`] = v.entries;
       },
-      {} as Record<string, Entry<any>[]>
+      {} as Record<string, CmsEntry<any>[]>
     );
 
     logger.debug(`Fetch entries by contentType`, {
@@ -209,10 +210,10 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
 
       timer = new Timer();
 
-      const filtered = filter(sourceResults, negate(isError)) as Entry<any>[][];
+      const filtered = filter(sourceResults, negate(isError)) as CmsEntry<any>[][];
 
       await Promise.all(
-        map(filtered, async (entries: Entry<any>[], i) => {
+        map(filtered, async (entries: CmsEntry<any>[], i) => {
           const key = cacheMissIds[i];
           return await Promise.all(
             map(entries, async (entry) =>
@@ -239,19 +240,19 @@ const createLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsLoaders): C
 
       keyedResults = {
         ...keyedResults,
-        ...(omitBy(keyedSourceResults, (v) => isError(v)) as Record<string, Entry<any>[]>)
+        ...(omitBy(keyedSourceResults, (v) => isError(v)) as Record<string, CmsEntry<any>[]>)
       };
     }
 
     return map(keys, (key) => keyedResults[`${key.id}::${key.preview}`] ?? []);
   };
 
-  const getBatchEntriesByFieldValueFetcher = (): DataLoader.BatchLoadFn<FVLKey, Entry<any> | null> => {
+  const getBatchEntriesByFieldValueFetcher = (): DataLoader.BatchLoadFn<FVLKey, CmsEntry<any> | null> => {
     return async (keys) => fallbackLoaders.entryByFieldValueLoader.loadMany(keys);
   };
 
-  const entryLoader = new DataLoader(getBatchItemFetcher<Entry<any>>('entries'), options);
-  const assetLoader = new DataLoader(getBatchItemFetcher<Asset>('assets'), options);
+  const entryLoader = new DataLoader(getBatchItemFetcher<CmsEntry<any>>('entries'), options);
+  const assetLoader = new DataLoader(getBatchItemFetcher<CmsAsset<any>>('assets'), options);
   const entriesByContentTypeLoader = new DataLoader(getBatchEntriesByContentTypeFetcher(), options);
   const fetchAllContentTypes = async (preview: boolean): Promise<ContentType[]> => {
     try {

--- a/packages/contentful-path-rules-engine/src/contentToPaths/ContentToPathsFetcher.ts
+++ b/packages/contentful-path-rules-engine/src/contentToPaths/ContentToPathsFetcher.ts
@@ -1,4 +1,4 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { ApolloContext, PathInfo } from '@last-rev/types';
 import traversePathRule, { PathVisitor } from '../core/traversePathRule';
 import {
@@ -163,7 +163,7 @@ export default class ContentToPathsFetcher {
     this._validator = new RelationShipValidator(pathRule);
   }
 
-  async fetch({ entry, apolloContext }: { entry: Entry<any>; apolloContext: ApolloContext }): Promise<PathInfo[]> {
+  async fetch({ entry, apolloContext }: { entry: CmsEntry<any>; apolloContext: ApolloContext }): Promise<PathInfo[]> {
     const pathInfos = await this._tree.fetch(entry, apolloContext);
     const validator = this._validator;
     return asyncFilter(pathInfos, async (pathInfo) => {

--- a/packages/contentful-path-rules-engine/src/contentToPaths/ContentToPathsFetcherTree.ts
+++ b/packages/contentful-path-rules-engine/src/contentToPaths/ContentToPathsFetcherTree.ts
@@ -1,4 +1,4 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { ApolloContext, ItemKey, PathInfo, RefByKey } from '@last-rev/types';
 
 export type ContentToPathTreeStaticNode = {
@@ -44,7 +44,7 @@ const isRootNode = (node: any): node is ContentToPathTreeRootNode => !node.type;
 
 const getRefNodeKeyObjects = (
   nodes: ContentToPathTreeRefNode[],
-  entries: Entry<any>[],
+  entries: CmsEntry<any>[],
   ctx: ApolloContext
 ): RefNodeKeyObject[] => {
   return entries
@@ -74,7 +74,7 @@ const getRefNodeKeyObjects = (
 
 const getRefByNodeKeyObjects = (
   nodes: ContentToPathTreeRefByNode[],
-  entries: Entry<any>[],
+  entries: CmsEntry<any>[],
   ctx: ApolloContext
 ): RefByNodeKeyObject[] => {
   return entries
@@ -110,7 +110,7 @@ export type ContentToPathsHasChildrenNode =
 
 export type SegmentInfo = {
   value: string;
-  entry: Entry<any> | null;
+  entry: CmsEntry<any> | null;
 };
 
 /**
@@ -124,7 +124,7 @@ const deepLoad = async ({
   delayedFields
 }: {
   node: ContentToPathTreeRefNode | ContentToPathTreeRefByNode;
-  entry: Entry<any>;
+  entry: CmsEntry<any>;
   ctx: ApolloContext;
   resolvedSlugs: (SegmentInfo | null)[][];
   delayedFields: { info: SegmentInfo; segmentIndex: number }[];
@@ -140,21 +140,21 @@ const deepLoad = async ({
     ctx.loaders.entriesRefByLoader.loadMany(refByNodeKeyObjects.map(({ key }) => key))
   ]);
 
-  const loadedRefNodes: { node: ContentToPathTreeRefNode; entry: Entry<any> }[] = [];
+  const loadedRefNodes: { node: ContentToPathTreeRefNode; entry: CmsEntry<any> }[] = [];
   const loadedRefByNodes: {
     node: ContentToPathTreeRefByNode;
-    entry: Entry<any>;
+    entry: CmsEntry<any>;
   }[] = [];
 
   refNodeKeyObjects.forEach(({ node }, i) => {
     const entry = loadedRefEntries[i];
-    if (entry && (entry as Entry<any>).sys.contentType.sys.id === node.contentType) {
-      loadedRefNodes.push({ node, entry: entry as Entry<any> });
+    if (entry && (entry as CmsEntry<any>).sys.contentType.sys.id === node.contentType) {
+      loadedRefNodes.push({ node, entry: entry as CmsEntry<any> });
     }
   });
 
   refByNodeKeyObjects.forEach(({ node }, i) => {
-    const entries = (loadedRefByEntries[i] as Entry<any>[]) || [];
+    const entries = (loadedRefByEntries[i] as CmsEntry<any>[]) || [];
     entries.forEach((entry) => {
       loadedRefByNodes.push({ node, entry });
     });
@@ -241,7 +241,7 @@ export default class ContentToPathsFetcherTree {
   private readonly _root: ContentToPathTreeRootNode = { children: [] };
   private _numSegments: number = 0;
 
-  async fetch(entry: Entry<any>, ctx: ApolloContext): Promise<PathInfo[]> {
+  async fetch(entry: CmsEntry<any>, ctx: ApolloContext): Promise<PathInfo[]> {
     const resolvedSlugs: (SegmentInfo | null)[][] = new Array(this._numSegments);
 
     for (var i = 0; i < resolvedSlugs.length; i++) {

--- a/packages/contentful-path-rules-engine/src/contentToPaths/ContentToPathsLoader.ts
+++ b/packages/contentful-path-rules-engine/src/contentToPaths/ContentToPathsLoader.ts
@@ -1,7 +1,7 @@
 import { ApolloContext, PathFilterFunction, PathInfo, PathRuleConfig } from '@last-rev/types';
 import { InternalRootConfig, PathRule } from '../types';
 import PathRuleParser from '../core/PathRuleParser';
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import ContentToPathsFetcher from './ContentToPathsFetcher';
 import { getRootConfig } from '../helpers';
 
@@ -46,7 +46,7 @@ export default class ContentToPathsLoader {
     this._rootConfig = getRootConfig(config);
   }
 
-  async loadPathsFromContent(entry: Entry<any>, ctx: ApolloContext, site?: string): Promise<PathInfo[]> {
+  async loadPathsFromContent(entry: CmsEntry<any>, ctx: ApolloContext, site?: string): Promise<PathInfo[]> {
     if (this._rootConfig) {
       const { field, value, contentType } = this._rootConfig;
       if (entry.sys.contentType.sys.id === contentType && entry.fields[field]?.[ctx.defaultLocale] === value) {

--- a/packages/contentful-path-rules-engine/src/core/RelationshipValidator.ts
+++ b/packages/contentful-path-rules-engine/src/core/RelationshipValidator.ts
@@ -1,13 +1,13 @@
 import { PathRule, RefByExpression, ReferenceExpression, SegmentReference } from '../types';
 import traversePathRule, { PathVisitor } from '../core/traversePathRule';
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { ApolloContext, PathEntries } from '@last-rev/types';
 import { getWinstonLogger } from '@last-rev/logging';
 
 const logger = getWinstonLogger({ package: 'contentful-path-rules-engine', module: 'RelationshipValidator' });
 
-type SegmentValidator = (item: Entry<any>, pathEntries: PathEntries, ctx: ApolloContext) => Promise<string | null>;
-type ResolutionRootsResolver = (pathEntries: PathEntries, ctx: ApolloContext) => Promise<Entry<any>[]>;
+type SegmentValidator = (item: CmsEntry<any>, pathEntries: PathEntries, ctx: ApolloContext) => Promise<string | null>;
+type ResolutionRootsResolver = (pathEntries: PathEntries, ctx: ApolloContext) => Promise<CmsEntry<any>[]>;
 
 type Context = {
   currentSegmentIndex: number;
@@ -36,7 +36,7 @@ const createRefResolutionRootsResolver = (
 
       return loaded.filter((a: any) => {
         return !!a?.sys?.id && a?.sys?.contentType?.sys?.id === contentType;
-      }) as Entry<any>[];
+      }) as CmsEntry<any>[];
     } catch (err: any) {
       logger.error(`Error resolving referce resolution roots: ${err.message}`, {
         caller: 'createRefResolutionRootsResolver',
@@ -62,7 +62,7 @@ const createRefbyResolutionRootsResolver = (
       );
       return settled
         .filter((s) => s.status === 'fulfilled')
-        .map((s) => (s as PromiseFulfilledResult<Entry<any>[]>).value)
+        .map((s) => (s as PromiseFulfilledResult<CmsEntry<any>[]>).value)
         .flat();
     } catch (err: any) {
       logger.error(`Error resolving refBy resolution roots: ${err.message}`, {
@@ -125,7 +125,7 @@ const relationshipValidationVisitor: PathVisitor<Context> = {
 
       context.getResolutionRoots = async (pathEntries) => {
         const lastValidEntry = pathEntries.reduce(
-          (acc: Entry<any> | null, curr: Entry<any> | null) => (curr ? curr : acc),
+          (acc: CmsEntry<any> | null, curr: CmsEntry<any> | null) => (curr ? curr : acc),
           null
         );
         return lastValidEntry ? [lastValidEntry] : [];

--- a/packages/contentful-path-rules-engine/src/pathToContent/PathToItemsFetcher.ts
+++ b/packages/contentful-path-rules-engine/src/pathToContent/PathToItemsFetcher.ts
@@ -1,4 +1,4 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { ApolloContext, CmsLoaders } from '@last-rev/types';
 import RelationShipValidator from '../core/RelationshipValidator';
 import traversePathRule, { PathVisitor } from '../core/traversePathRule';
@@ -14,7 +14,7 @@ export type NoMatchFieldValueResult = {
 export type MatchedFieldValueResult = {
   found: true;
   segmentIndex: number;
-  entry: Entry<any>;
+  entry: CmsEntry<any>;
 };
 
 const isNoMatchFieldValueResult = (x: any): x is NoMatchFieldValueResult => {
@@ -118,7 +118,7 @@ export default class PathToItemsFetcher {
     const results = (resolved as MatchedFieldValueResult[]).reduce((acc, curr) => {
       acc[curr.segmentIndex] = curr.entry;
       return acc;
-    }, new Array(slugs.length).fill(null) as (Entry<any> | null)[]);
+    }, new Array(slugs.length).fill(null) as (CmsEntry<any> | null)[]);
 
     const errors = await this._relationshipValidator.validate(results, apolloContext);
 

--- a/packages/contentful-path-rules-engine/src/testUtils.ts
+++ b/packages/contentful-path-rules-engine/src/testUtils.ts
@@ -1,7 +1,7 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { ApolloContext, ItemKey, RefByKey, FVLKey } from '@last-rev/types';
 
-export const createMockEntry = (id: string, contentType: string, fields: Record<string, any>): Entry<any> => {
+export const createMockEntry = (id: string, contentType: string, fields: Record<string, any>): CmsEntry<any> => {
   return {
     sys: {
       id,
@@ -17,7 +17,7 @@ export const createMockEntry = (id: string, contentType: string, fields: Record<
       };
       return acc;
     }, {} as Record<string, any>)
-  } as unknown as Entry<any>;
+  } as unknown as CmsEntry<any>;
 };
 
 export const entryMocks = {

--- a/packages/contentful-path-util/src/PathNode.ts
+++ b/packages/contentful-path-util/src/PathNode.ts
@@ -1,5 +1,4 @@
-import { ApolloContext, iPathNode, ItemKey, PathData, PathEntries } from '@last-rev/types';
-import { Entry } from 'contentful';
+import { ApolloContext, iPathNode, ItemKey, PathData, PathEntries, CmsEntry } from '@last-rev/types';
 
 export class PathNode implements iPathNode {
   data?: PathData;
@@ -40,10 +39,10 @@ export class PathNode implements iPathNode {
     const fetchedEntries = await ctx.loaders.entryLoader.loadMany(keysToFetch);
     const entriesById = fetchedEntries.reduce((acc: any, entry: any) => {
       if (entry) {
-        acc[(entry as Entry<any>).sys.id] = entry as Entry<any>;
+        acc[(entry as CmsEntry<any>).sys.id] = entry as CmsEntry<any>;
       }
       return acc;
-    }, {} as Record<string, Entry<any>>);
+    }, {} as Record<string, CmsEntry<any>>);
 
     node = this;
 

--- a/packages/contentful-redis-loader/src/primers.ts
+++ b/packages/contentful-redis-loader/src/primers.ts
@@ -3,7 +3,7 @@ import Timer from '@last-rev/timer';
 import { ItemKey } from '@last-rev/types';
 import { getKey, isNil, isRejected, stringify } from './helpers';
 import { getWinstonLogger } from '@last-rev/logging';
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 
 const logger = getWinstonLogger({ package: 'contentful-redis-loader', module: 'primers' });
 
@@ -76,7 +76,7 @@ export const primeRedisEntriesOrAssets = async <T>(
 
 export const primeRedisEntriesByContentType = async (
   client: Redis,
-  filtered: (Entry<any>[] | Error)[],
+  filtered: (CmsEntry<any>[] | Error)[],
   cacheMissContentTypeIds: ItemKey[],
   maxBatchSize: number,
   ttlSeconds: number
@@ -89,7 +89,7 @@ export const primeRedisEntriesByContentType = async (
     let count = 0;
     let msetKeys: Record<string, string> = {};
 
-    (filtered as Entry<any>[][]).forEach((entries, index) => {
+    (filtered as CmsEntry<any>[][]).forEach((entries, index) => {
       const { id: contentType, preview } = cacheMissContentTypeIds[index];
       const rootKey = getKey({ preview, id: contentType }, 'entry_ids_by_content_type');
 

--- a/packages/contentful-sync-to-fs/src/index.ts
+++ b/packages/contentful-sync-to-fs/src/index.ts
@@ -5,7 +5,8 @@ import groupBy from 'lodash/fp/groupBy';
 import mapValues from 'lodash/fp/mapValues';
 import { join } from 'path';
 import { readFile, ensureDir, writeFile, createFile } from 'fs-extra';
-import { Asset, Entry, createClient, ContentfulClientApi, ContentType, SyncCollection } from 'contentful';
+import { createClient, ContentfulClientApi, ContentType, SyncCollection } from 'contentful';
+import { CmsEntry, CmsAsset } from '@last-rev/types';
 import Timer from '@last-rev/timer';
 import { getWinstonLogger } from '@last-rev/logging';
 import LastRevAppConfig from '@last-rev/app-config';
@@ -43,7 +44,7 @@ const groupByContentTypeAndMapToIds = flow(
 );
 
 const writeContentfulItems = async (
-  items: (Entry<any> | Asset | ContentType)[],
+  items: (CmsEntry<any> | CmsAsset<any> | ContentType)[],
   root: string,
   dirname: string
 ): Promise<void> => {

--- a/packages/contentful-webhook-handler/src/dynamodbHandlers.ts
+++ b/packages/contentful-webhook-handler/src/dynamodbHandlers.ts
@@ -5,7 +5,7 @@ import { DynamoDB, QueryCommandOutput } from '@aws-sdk/client-dynamodb';
 import { updateAllPaths } from '@last-rev/contentful-path-util';
 import { createContext } from '@last-rev/graphql-contentful-helpers';
 import { assetHasUrl, createContentfulClients } from './helpers';
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { map } from 'lodash';
 
 export const createDynamoDbHandlers = (config: LastRevAppConfig): Handlers => {
@@ -94,7 +94,7 @@ export const createDynamoDbHandlers = (config: LastRevAppConfig): Handlers => {
   const refreshEntriesByContentType = async (contentTypeId: string, isPreview: boolean) => {
     const client = isPreview ? contentfulPreviewClient : contentfulProdClient;
 
-    const makeRequest = async (skip: number = 0, existing: Entry<any>[] = []): Promise<Entry<any>[]> => {
+    const makeRequest = async (skip: number = 0, existing: CmsEntry<any>[] = []): Promise<CmsEntry<any>[]> => {
       const results = await client.getEntries({
         content_type: contentTypeId,
         locale: '*',

--- a/packages/contentful-webhook-handler/src/helpers.ts
+++ b/packages/contentful-webhook-handler/src/helpers.ts
@@ -1,5 +1,6 @@
 import { each } from 'lodash';
-import { Asset, createClient, Entry, ContentType } from 'contentful';
+import { createClient, ContentType } from 'contentful';
+import { CmsEntry, CmsAsset } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 import { getWinstonLogger } from '@last-rev/logging';
 
@@ -53,7 +54,7 @@ export const isContentfulError = (item: any) => {
   return item?.sys?.type === 'Error';
 };
 
-export const isContentfulObject = (item: any): item is Entry<any> | Asset | ContentType => {
+export const isContentfulObject = (item: any): item is CmsEntry<any> | CmsAsset<any> | ContentType => {
   return item?.sys?.type === 'Entry' || item?.sys?.type === 'Asset' || item?.sys?.type === 'ContentType';
 };
 

--- a/packages/contentful-webhook-handler/src/index.ts
+++ b/packages/contentful-webhook-handler/src/index.ts
@@ -1,4 +1,5 @@
-import { Entry, Asset, createClient, ContentTypeCollection } from 'contentful';
+import { createClient, ContentTypeCollection } from 'contentful';
+import { CmsEntry, CmsAsset } from '@last-rev/types';
 import { map } from 'lodash';
 import LastRevAppConfig from '@last-rev/app-config';
 import { ProcessCommand } from './types';
@@ -84,10 +85,10 @@ const handleWebhook = async (config: LastRevAppConfig, body: any, headers: Recor
         };
         switch (type) {
           case 'Asset':
-            await handlers.asset(command as ProcessCommand<Asset>);
+            await handlers.asset(command as ProcessCommand<CmsAsset<any>>);
             break;
           case 'Entry':
-            await handlers.entry(command as ProcessCommand<Entry<any>>);
+            await handlers.entry(command as ProcessCommand<CmsEntry<any>>);
             break;
           case 'ContentType':
             await handlers.contentType(command as ProcessCommand<ContentTypeCollection>);

--- a/packages/contentful-webhook-handler/src/types.ts
+++ b/packages/contentful-webhook-handler/src/types.ts
@@ -1,14 +1,15 @@
-import { Entry, Asset, ContentTypeCollection } from 'contentful';
+import { ContentTypeCollection } from 'contentful';
+import { CmsEntry, CmsAsset } from '@last-rev/types';
 
-export type ProcessCommand<T extends Entry<any> | Asset | ContentTypeCollection> = {
+export type ProcessCommand<T extends CmsEntry<any> | CmsAsset<any> | ContentTypeCollection> = {
   isPreview: boolean;
   action: 'update' | 'delete';
   data: T;
 };
 
 export type Handlers = {
-  entry: (data: ProcessCommand<Entry<any>>) => Promise<void>;
-  asset: (data: ProcessCommand<Asset>) => Promise<void>;
+  entry: (data: ProcessCommand<CmsEntry<any>>) => Promise<void>;
+  asset: (data: ProcessCommand<CmsAsset<any>>) => Promise<void>;
   contentType: (data: ProcessCommand<ContentTypeCollection>) => Promise<void>;
   paths: (applyToPreview: boolean, applyToProduction: boolean) => Promise<void>;
 };

--- a/packages/contentful-webhook-parser/src/index.ts
+++ b/packages/contentful-webhook-parser/src/index.ts
@@ -1,4 +1,5 @@
-import { Entry, Asset, ContentType } from 'contentful';
+import { ContentType } from 'contentful';
+import { CmsEntry, CmsAsset } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
 import { getWinstonLogger } from '@last-rev/logging';
 
@@ -37,7 +38,7 @@ const actionMappings: ActionMappings = {
   archive: { action: 'delete', envs: ['preview', 'production'] }
 };
 
-export type WebhookBody = (Entry<any> | Asset | ContentType) & HasEnv;
+export type WebhookBody = (CmsEntry<any> | CmsAsset<any> | ContentType) & HasEnv;
 export type WebhookHeaders = Record<string, string>;
 export type WebhookParserResult = {
   action: 'update' | 'delete';

--- a/packages/graphql-algolia-integration/src/constructObjectId.test.ts
+++ b/packages/graphql-algolia-integration/src/constructObjectId.test.ts
@@ -1,12 +1,12 @@
 import constructObjectId from './constructObjectId';
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { ApolloContext } from '@last-rev/types';
 
 const content = {
   sys: {
     id: 'foo'
   }
-} as unknown as Entry<any>;
+} as unknown as CmsEntry<any>;
 
 let context: ApolloContext;
 

--- a/packages/graphql-contentful-core/src/resolvers/contentItem.mock.ts
+++ b/packages/graphql-contentful-core/src/resolvers/contentItem.mock.ts
@@ -1,4 +1,4 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 
 const content = {
   sys: {
@@ -72,6 +72,6 @@ const content = {
       ]
     }
   }
-} as unknown as Entry<any>;
+} as unknown as CmsEntry<any>;
 
 export default content;

--- a/packages/graphql-contentful-core/src/resolvers/createResolvers.ts
+++ b/packages/graphql-contentful-core/src/resolvers/createResolvers.ts
@@ -1,5 +1,6 @@
 import { GraphQLScalarType } from 'graphql';
-import { ContentType, Entry } from 'contentful';
+import { ContentType } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import GraphQLJSON from 'graphql-type-json';
 import getContentResolvers from './getContentResolvers';
 import fieldsResolver from './fieldsResolver';
@@ -104,7 +105,7 @@ const createResolvers = ({ contentTypes, config }: { contentTypes: ContentType[]
           if (contentTypes.length) {
             const results = (
               await ctx.loaders.entriesByContentTypeLoader.loadMany(contentTypes.map((type) => ({ id: type, preview })))
-            ).filter((r: any) => !isError(r)) as unknown as Entry<any>[];
+            ).filter((r: any) => !isError(r)) as unknown as CmsEntry<any>[];
 
             return results.flat();
           }
@@ -201,11 +202,11 @@ const createResolvers = ({ contentTypes, config }: { contentTypes: ContentType[]
               skip: (page - 1) * maxPageSize,
               order: 'sys.updatedAt'
             })
-          ).items.map((item: Entry<any>) => item.sys.id);
+          ).items.map((item: CmsEntry<any>) => item.sys.id);
 
           const entries = (await ctx.loaders.entryLoader.loadMany(ids.map((id: string) => ({ id, preview })))).filter(
             (e: any) => !!e && !isError(e)
-          ) as Entry<any>[];
+          ) as CmsEntry<any>[];
 
           const sitemapEntries = (
             await Promise.all(

--- a/packages/graphql-contentful-core/src/resolvers/fieldResolver.ts
+++ b/packages/graphql-contentful-core/src/resolvers/fieldResolver.ts
@@ -1,4 +1,4 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { GraphQLResolveInfo } from 'graphql';
 import { ApolloContext } from '@last-rev/types';
 import getTypeName from '../utils/getTypeName';
@@ -20,7 +20,7 @@ export type Resolver<TSource, TContext> = (
   info: GraphQLResolveInfo
 ) => Promise<any>;
 
-type FieldResolver = <T>(displayType: string) => Resolver<Entry<T>, ApolloContext>;
+type FieldResolver = <T>(displayType: string) => Resolver<CmsEntry<T>, ApolloContext>;
 
 const fieldResolver: FieldResolver = (displayTypeArg: string) => async (content, args, ctx, info) => {
   const { fieldName: field } = info;

--- a/packages/graphql-contentful-core/src/utils/getDefaultFieldValue.ts
+++ b/packages/graphql-contentful-core/src/utils/getDefaultFieldValue.ts
@@ -1,7 +1,7 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import { get } from 'lodash';
 
-const getDefaultFieldValue = (item: Entry<any>, fieldName: string, defaultLocale: string): any | null =>
+const getDefaultFieldValue = (item: CmsEntry<any>, fieldName: string, defaultLocale: string): any | null =>
   get(item, ['fields', fieldName, defaultLocale], null);
 
 export default getDefaultFieldValue;

--- a/packages/graphql-contentful-core/src/utils/getLocalizedField.ts
+++ b/packages/graphql-contentful-core/src/utils/getLocalizedField.ts
@@ -1,8 +1,8 @@
-import { Entry } from 'contentful';
+import { CmsEntry } from '@last-rev/types';
 import get from 'lodash/get';
 import { ApolloContext } from '@last-rev/types';
 
-const getLocalizedField = <T>(fields: Entry<T>['fields'], field: string, ctx: ApolloContext) => {
+const getLocalizedField = <T>(fields: CmsEntry<T>['fields'], field: string, ctx: ApolloContext) => {
   const defaultLocaleValue = get(fields, [field, ctx.defaultLocale]); // undefined
   const localeValue = get(fields, [field, ctx.locale ?? ctx.defaultLocale]); // "value""
   if (typeof localeValue !== 'undefined') return localeValue;

--- a/packages/graphql-contentful-extensions/src/Page.ts
+++ b/packages/graphql-contentful-extensions/src/Page.ts
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag';
 import { getLocalizedField } from '@last-rev/graphql-contentful-core';
-import { ApolloContext } from '@last-rev/types';
-import { Entry } from 'contentful';
+import { ApolloContext, CmsEntry } from '@last-rev/types';
 import resolveLocalizedField from './utils/resolveLocalizedField';
 import { blogV1, categoryBlogV1, pageV1 } from './PathsConfigs';
 export const typeMappings = {};
@@ -45,7 +44,7 @@ const createType = (type: string, content: any) => ({
 
 const pageContentsResolver = async (page: any, _args: any, ctx: ApolloContext) => {
   // Get the PAge contents
-  const contents = (await resolveLocalizedField(page.fields, 'contents', ctx)) as Entry<any>[];
+  const contents = (await resolveLocalizedField(page.fields, 'contents', ctx)) as CmsEntry<any>[];
 
   // Map the Page contents (if not a Section wrap it)
   return contents?.map((content) => {

--- a/packages/graphql-contentful-extensions/src/PathsConfigs.ts
+++ b/packages/graphql-contentful-extensions/src/PathsConfigs.ts
@@ -1,13 +1,12 @@
 import { getDefaultFieldValue } from '@last-rev/graphql-contentful-core';
-import { CmsLoaders, ContentTypePathRuleConfig, LegacyContentfulPathsConfigs } from '@last-rev/types';
-import { Entry } from 'contentful';
+import { CmsLoaders, ContentTypePathRuleConfig, LegacyContentfulPathsConfigs, CmsEntry } from '@last-rev/types';
 import createPath from './utils/createPath';
 
 const BLOGS_LANDING_ID = process.env.BLOGS_LANDING_ID;
 
 // Path generation
 const validateSite = async (_args: {
-  item: Entry<any>;
+  item: CmsEntry<any>;
   loaders: CmsLoaders;
   defaultLocale: string;
   locales: string[];

--- a/packages/graphql-contentful-extensions/src/RichText.ts
+++ b/packages/graphql-contentful-extensions/src/RichText.ts
@@ -1,5 +1,5 @@
-import { ApolloContext, Mappers } from '@last-rev/types';
-import { Entry, RichTextContent } from 'contentful';
+import { ApolloContext, Mappers, CmsEntry } from '@last-rev/types';
+import { RichTextContent } from 'contentful';
 import { FilterXSS } from 'xss';
 import isHTML from './utils/isHTML';
 
@@ -95,7 +95,7 @@ export const mappers: Mappers = {
         ]);
 
         // Loop through entries and if included in hyperlinks will change type to a "Link" to utilize mappers for that type
-        const tidiedEntries = await entries.filter(Boolean).map(async (entry: Entry<any> | Error | null) => {
+        const tidiedEntries = await entries.filter(Boolean).map(async (entry: CmsEntry<any> | Error | null) => {
           if (!entry) return entry;
 
           const id = (entry as any)?.sys?.id;

--- a/packages/graphql-contentful-extensions/src/utils/queryContentful.ts
+++ b/packages/graphql-contentful-extensions/src/utils/queryContentful.ts
@@ -1,5 +1,4 @@
-import { ApolloContext } from '@last-rev/types';
-import { Entry } from 'contentful';
+import { ApolloContext, CmsEntry } from '@last-rev/types';
 
 interface QueryArgs {
   contentType: string;
@@ -18,7 +17,7 @@ const query = async ({
   limit = 1000,
   skip = 0,
   ctx
-}: QueryArgs): Promise<Entry<unknown>[]> => {
+}: QueryArgs): Promise<CmsEntry<unknown>[]> => {
   let items;
   const contentfulQuery = {
     content_type: contentType,
@@ -57,7 +56,7 @@ export const queryContentful = async ({
   limit = 1000,
   skip = 0,
   ctx
-}: QueryArgs): Promise<Entry<unknown>[]> => {
+}: QueryArgs): Promise<CmsEntry<unknown>[]> => {
   return query({
     contentType,
     filters,

--- a/packages/graphql-contentful-extensions/src/utils/resolveLocalizedField.ts
+++ b/packages/graphql-contentful-extensions/src/utils/resolveLocalizedField.ts
@@ -1,11 +1,10 @@
 import { getLocalizedField } from '@last-rev/graphql-contentful-core';
-import { ApolloContext } from '@last-rev/types';
-import { Asset, Entry } from 'contentful';
+import { ApolloContext, CmsEntry, CmsAsset } from '@last-rev/types';
 
 interface FieldReferenceValue {
   sys: { linkType: string };
 }
-type ResolvedValue = Asset | Entry<any> | null | Array<Asset | Entry<any> | null>;
+type ResolvedValue = CmsAsset<any> | CmsEntry<any> | null | Array<CmsAsset<any> | CmsEntry<any> | null>;
 export const resolveLocalizedField = async (fields: any, field: string, ctx: ApolloContext): Promise<ResolvedValue> => {
   const { loaders, preview } = ctx;
   let value: FieldReferenceValue | any = getLocalizedField(fields, field, ctx);
@@ -17,12 +16,12 @@ export const resolveLocalizedField = async (fields: any, field: string, ctx: Apo
       // contentful cannot have mixed arrays, so it is okay to make assumptions based on the first item
       return (await loaders.entryLoader.loadMany(value.map((x) => ({ id: x.sys.id, preview: !!preview }))))
         .filter((r) => r !== null)
-        .map((r) => r as Entry<any>);
+        .map((r) => r as CmsEntry<any>);
     }
     if (firstItem?.sys?.linkType === 'Asset') {
       return (await loaders.assetLoader.loadMany(value.map((x) => ({ id: x.sys.id, preview: !!preview }))))
         .filter((r) => r !== null)
-        .map((r) => r as Entry<any>);
+        .map((r) => r as CmsEntry<any>);
     }
   }
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,6 +1,25 @@
 import DataLoader from 'dataloader';
-import { Entry, Asset, ContentType, ContentfulClientApi } from 'contentful';
+import { ContentType, ContentfulClientApi } from 'contentful';
 import { GraphQLSchema, Source, DocumentNode } from 'graphql';
+
+export interface CmsSys {
+  id: string;
+  contentType?: { sys: { id: string } };
+  updatedAt?: string;
+  [key: string]: any;
+}
+
+export interface CmsEntry<T = any> {
+  sys: CmsSys;
+  fields: T;
+  [key: string]: any;
+}
+
+export interface CmsAsset<T = any> {
+  sys: CmsSys;
+  fields: T;
+  [key: string]: any;
+}
 
 export type ItemKey = {
   id: string;
@@ -39,11 +58,11 @@ export type RefByKey = {
 };
 
 export type CmsLoaders = {
-  entryLoader: DataLoader<ItemKey, Entry<any> | null>;
-  entriesRefByLoader: DataLoader<RefByKey, Entry<any>[]>;
-  entryByFieldValueLoader: DataLoader<FVLKey, Entry<any> | null>;
-  assetLoader: DataLoader<ItemKey, Asset | null>;
-  entriesByContentTypeLoader: DataLoader<ItemKey, Entry<any>[]>;
+  entryLoader: DataLoader<ItemKey, CmsEntry<any> | null>;
+  entriesRefByLoader: DataLoader<RefByKey, CmsEntry<any>[]>;
+  entryByFieldValueLoader: DataLoader<FVLKey, CmsEntry<any> | null>;
+  assetLoader: DataLoader<ItemKey, CmsAsset<any> | null>;
+  entriesByContentTypeLoader: DataLoader<ItemKey, CmsEntry<any>[]>;
   // pathLoader: DataLoader<PathKey, PathData2 | null>;
   fetchAllContentTypes: (preview: boolean) => Promise<ContentType[]>;
 };
@@ -53,7 +72,7 @@ export type TypeMappings = {
 };
 
 export type ContentfulPathsGenerator = (
-  resolvedItem: Entry<any>,
+  resolvedItem: CmsEntry<any>,
   loaders: CmsLoaders,
   defaultLocale: string,
   locales: string[],
@@ -117,7 +136,7 @@ export type CmsClients =
       preview: any;
     };
 
-export type PathEntries = (Entry<any> | null)[];
+export type PathEntries = (CmsEntry<any> | null)[];
 
 export type PathInfo = {
   path: string;
@@ -130,7 +149,7 @@ export type LoadEntriesForPathFunction = (
   site?: string
 ) => Promise<PathEntries | null>;
 
-export type loadPathsForContentFunction = (entry: Entry<any>, ctx: ApolloContext, site?: string) => Promise<PathInfo[]>;
+export type loadPathsForContentFunction = (entry: CmsEntry<any>, ctx: ApolloContext, site?: string) => Promise<PathInfo[]>;
 
 export type ApolloContext = {
   loaders: CmsLoaders;


### PR DESCRIPTION
## Summary
- define generic `CmsEntry` and `CmsAsset` interfaces
- update loaders and utilities to use new CMS types

## Testing
- `yarn test` *(fails: Connect Timeout Error)*