### PR TITLE
Fix Sanity type name mapping

### DIFF
--- a/packages/graphql-contentful-core/src/resolvers/createResolvers.ts
+++ b/packages/graphql-contentful-core/src/resolvers/createResolvers.ts
@@ -238,7 +238,10 @@ const createResolvers = ({ contentTypes, config }: { contentTypes: ContentType[]
         __resolveType: (content: any, ctx: ApolloContext) => {
           if (ctx.displayType) return ctx.displayType;
           if (content.sys && (content.sys.linkType == 'Asset' || content.sys.type === 'Asset')) return 'Media';
-          const contentTypeId = content.__typename ? content.__typename : content.sys.contentType.sys.id;
+          let contentTypeId = content.__typename ? content.__typename : content.sys.contentType.sys.id;
+          if (config.cms === 'Sanity' && /^Contentful_/i.test(contentTypeId)) {
+            contentTypeId = contentTypeId.replace(/^Contentful_/i, '');
+          }
           return getTypeName(contentTypeId, config.extensions.typeMappings);
         }
       },

--- a/packages/graphql-contentful-core/src/utils/getTypeName.test.ts
+++ b/packages/graphql-contentful-core/src/utils/getTypeName.test.ts
@@ -22,6 +22,12 @@ describe('getTypeName.ts', () => {
     expect(typeName).toEqual('Bar');
   });
 
+  it('should strip the Contentful_ prefix from type names', () => {
+    const contentTypeId = 'Contentful_text';
+    const typeName = getTypeName(contentTypeId, typeMappings);
+    expect(typeName).toEqual('Text');
+  });
+
   it('should get the typename from a content type when no mapping is defined', () => {
     const contentType = { sys: { id: 'foo' } } as unknown as ContentType;
     const typeName = getTypeName(contentType, typeMappings);

--- a/packages/graphql-contentful-core/src/utils/getTypeName.ts
+++ b/packages/graphql-contentful-core/src/utils/getTypeName.ts
@@ -4,7 +4,14 @@ import isString from 'lodash/isString';
 import capitalizeFirst from './capitalizeFirst';
 
 const getTypeName = (contentType: ContentType | string, typeMappings: TypeMappings): string => {
-  const contentTypeId = isString(contentType) ? contentType : contentType.sys.id;
+  let contentTypeId = isString(contentType) ? contentType : contentType.sys.id;
+
+  // Sanity migrations may prefix types with "Contentful_". Normalize these back
+  // to the original name so that existing code expecting the Contentful styled
+  // names continues to work.
+  if (/^Contentful_/i.test(contentTypeId)) {
+    contentTypeId = contentTypeId.replace(/^Contentful_/i, '');
+  }
 
   return capitalizeFirst(typeMappings[contentTypeId] ?? contentTypeId);
 };

--- a/packages/graphql-schema-gen/src/fetchers/contentful.ts
+++ b/packages/graphql-schema-gen/src/fetchers/contentful.ts
@@ -82,6 +82,11 @@ type ${upperFirst(contentType.sys.id)} implements Content {
 
 const mapContentTypeIds = (type: ContentType, typeMappings: Record<string, string>): ContentType => {
   let contentTypeId = type.sys.id;
+  // Sanity migrations may prefix schema type names with "Contentful_". Strip the
+  // prefix so that the generated GraphQL schema uses the original type name.
+  if (/^Contentful_/i.test(contentTypeId)) {
+    contentTypeId = contentTypeId.replace(/^Contentful_/i, '');
+  }
   if (has(typeMappings, contentTypeId)) {
     contentTypeId = typeMappings[contentTypeId];
   }


### PR DESCRIPTION
## Summary
- normalize Contentful_ prefixes when generating schemas
- adjust getTypeName util to strip Contentful_ prefix
- support Sanity prefixed types in type resolver
- test stripping of Contentful_ prefix

## Testing
- `yarn test` *(fails: connect EHOSTUNREACH)*