### PR TITLE
Fix Redis key prefix generation for Sanity CMS configurations

### DIFF
--- a/.changeset/tricky-snakes-relax.md
+++ b/.changeset/tricky-snakes-relax.md
@@ -1,0 +1,12 @@
+---
+'@last-rev/cms-redis-loader': patch
+---
+
+Fix Redis key prefix generation for Sanity CMS configurations
+
+- Add proper support for Sanity CMS in Redis client creation
+- Use correct projectId:dataset key prefix for Sanity instead of defaulting to Contentful format
+- Prevents Redis entries from being created with incorrect "undefined:master" paths
+- Maintains backward compatibility with existing Contentful configurations
+
+Fixes DIL-24

--- a/packages/cms-redis-loader/src/index.ts
+++ b/packages/cms-redis-loader/src/index.ts
@@ -27,11 +27,16 @@ const flvOptions: Options<FVLKey, any, string> = {
 };
 
 const getClient = (config: LastRevAppConfig) => {
-  const key = JSON.stringify([config.redis, config.contentful.spaceId, config.contentful.env]);
+  const key = config.cms === 'Sanity'
+    ? JSON.stringify([config.redis, config.sanity.projectId, config.sanity.dataset])
+    : JSON.stringify([config.redis, config.contentful.spaceId, config.contentful.env]);
+    
   if (!clients[key]) {
     clients[key] = new Redis({
       ...config.redis,
-      keyPrefix: `${config.contentful.spaceId}:${config.contentful.env}:`
+      keyPrefix: `${config.cms === 'Sanity' ? config.sanity.projectId : config.contentful.spaceId}:${
+        config.cms === 'Sanity' ? config.sanity.dataset : config.contentful.env
+      }:`
     });
   }
   return clients[key];


### PR DESCRIPTION
## Summary
- Add proper support for Sanity CMS in Redis client creation
- Use correct projectId:dataset key prefix for Sanity instead of defaulting to Contentful format
- Prevents Redis entries from being created with incorrect "undefined:master" paths
- Maintains backward compatibility with existing Contentful configurations

## Test plan
- [ ] Test webhook processing with Sanity CMS configuration
- [ ] Verify Redis keys are created with correct projectId:dataset prefix
- [ ] Confirm no regression with existing Contentful configurations
- [ ] Test that path building works correctly with proper Redis keys

Fixes DIL-24