### PR TITLE
(Likely Not Needed) Enhance asset mapping by preserving custom image fields in metadata.

### DIFF
--- a/packages/sanity-mapper/src/index.test.ts
+++ b/packages/sanity-mapper/src/index.test.ts
@@ -409,4 +409,57 @@ describe('convertSanityDoc', () => {
       }
     });
   });
+
+  it('should preserve custom image fields under metadata.assetFields when mapping asset links', () => {
+    const doc = {
+      _id: '123',
+      _type: 'article',
+      _updatedAt: '2025-06-13T13:12:36Z',
+      _createdAt: '2021-12-16T19:21:12Z',
+      logo: {
+        _type: 'image',
+        alt: 'Logo alt',
+        description: 'logo alt description',
+        asset: {
+          _ref: 'image-7c0d292a720d2da7711cbd08682ba2b16e316808-1563x264-svg',
+          _type: 'reference'
+        }
+      }
+    };
+
+    const result = convertSanityDoc(doc, defaultLocale, locales);
+
+    expect(result).toEqual({
+      sys: {
+        id: '123',
+        type: 'Entry',
+        updatedAt: '2025-06-13T13:12:36Z',
+        createdAt: '2021-12-16T19:21:12Z',
+        contentType: {
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: 'article'
+          }
+        }
+      },
+      fields: {
+        logo: {
+          'en-US': {
+            sys: {
+              type: 'Link',
+              linkType: 'Asset',
+              id: 'image-7c0d292a720d2da7711cbd08682ba2b16e316808-1563x264-svg'
+            },
+            metadata: {
+              assetFields: {
+                alt: 'Logo alt',
+                description: 'logo alt description'
+              }
+            }
+          }
+        }
+      }
+    });
+  });
 });

--- a/packages/sanity-mapper/src/index.ts
+++ b/packages/sanity-mapper/src/index.ts
@@ -1,6 +1,22 @@
 import { mapSanityPortableTextArrayToContentfulRichText } from './richTextHelpers';
 import type { ContentType, BaseAsset, BaseEntry } from '@last-rev/types';
 
+const mapSanityAssetLinkMetadata = (value: any, defaultLocale: string): Record<string, any> | undefined => {
+  const { _type, asset, ...assetFields } = value || {};
+  if (!Object.keys(assetFields).length) return undefined;
+
+  const mappedAssetFields = Object.entries(assetFields).reduce((acc: Record<string, any>, [key, fieldValue]) => {
+    acc[key] = mapSanityValueToContentful(fieldValue, defaultLocale);
+    return acc;
+  }, {});
+
+  if (!Object.keys(mappedAssetFields).length) return undefined;
+
+  return {
+    assetFields: mappedAssetFields
+  };
+};
+
 export const mapSanityValueToContentful = (value: any, defaultLocale: string): any => {
   // Detect Sanity rich text (Block[])
   if (Array.isArray(value) && value[0] && (value[0]._type === 'block' || value[0]._type === 'break')) {
@@ -17,12 +33,14 @@ export const mapSanityValueToContentful = (value: any, defaultLocale: string): a
     // Handle Sanity asset reference (image/file) - must come before reference check
     // since image.asset has _type: 'reference'
     if ((value._type === 'image' || value._type === 'file') && value.asset?._ref) {
+      const metadata = mapSanityAssetLinkMetadata(value, defaultLocale);
       return {
         sys: {
           type: 'Link',
           linkType: 'Asset',
           id: value.asset._ref
-        }
+        },
+        ...(metadata && { metadata })
       };
     }
     // Handle Sanity reference


### PR DESCRIPTION
## 📝 Summary

Enhance asset mapping by preserving custom image fields in metadata. Added a new function to map asset link metadata, ensuring that custom fields are included when converting Sanity documents to Contentful format. Updated tests to verify the correct handling of these fields.
---

### 🔹 Linked JIRA Ticket

[PROJKEY](https://lastrev.atlassian.net/browse/PROJKEY)

---

### 🔗 Preview URL

[Deploy Preview URL](https://deploy-preview-XXX--NETLIFYURL.netlify.app/)

---

### 🔬 Testing Instructions

Please list detailed steps for how to test this PR, including any relevant context or preconditions.

1.
2. ...

---

### 🖼️ Screenshots or screen recordings (if applicable)

Please include any visual changes introduced by this PR. This is particularly important for UI-related changes.

---

### ✔️ Checklist

Please ensure all these boxes are checked before submitting the PR.

- [ ] I have tested this change in accordance with the instructions provided above.
- [ ] I have linked this PR to a JIRA ticket.
- [ ] I have updated/added any necessary documentation.
- [ ] I have added and committed all relevant code changes.
- [ ] I have merged the latest changes from the target branch into this branch.

---

### 🚀 Changes include

Please classify the type of change introduced by this PR:

- [ ] Bug Fix (_non-breaking change that solves an issue_)
- [ ] New Feature (_non-breaking change that adds functionality_)
- [ ] Breaking Change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation Update
- [ ] Redirect
- [ ] Release
- [ ] Other

---

### 📚 Additional Context (if any)

Please include any other relevant information or context about this PR.
