### PR TITLE
Support non-Contentful data sources in Redis loader

### DIFF
--- a/.changeset/polite-bugs-tan.md
+++ b/.changeset/polite-bugs-tan.md
@@ -1,0 +1,5 @@
+---
+'@last-rev/cms-redis-loader': patch
+---
+
+Updated cms redis loader to support sanity objects

--- a/packages/cms-redis-loader/src/helpers.test.ts
+++ b/packages/cms-redis-loader/src/helpers.test.ts
@@ -8,7 +8,8 @@ import {
   enhanceContentfulObjectWithMetadata,
   isContentfulObject,
   isContentfulError,
-  stringify
+  stringify,
+  stringifyContentful
 } from './helpers';
 
 // Mock the logger
@@ -180,55 +181,80 @@ describe('helpers', () => {
   });
 
   describe('stringify', () => {
-    it('should stringify valid Contentful entries', () => {
+    it('should stringify any valid object', () => {
+      const obj = { id: 'test', data: 'value' };
+      const result = stringify(obj, 'test-key');
+      expect(result).toBeDefined();
+      expect(JSON.parse(result!)).toEqual(obj);
+    });
+
+    it('should stringify Sanity documents', () => {
+      const doc = { _id: 'doc-1', _type: 'page', title: 'Hello' };
+      const result = stringify(doc, 'test-key');
+      expect(result).toBeDefined();
+      expect(JSON.parse(result!)).toEqual(doc);
+    });
+
+    it('should stringify Contentful entries without metadata', () => {
+      const entry = { sys: { type: 'Entry', id: 'test' }, fields: { title: 'Test' } };
+      const result = stringify(entry, 'test-key');
+      expect(result).toBeDefined();
+      const parsed = JSON.parse(result!);
+      expect(parsed.sys).toEqual(entry.sys);
+      expect(parsed.lastrev_metadata).toBeUndefined();
+    });
+
+    it('should return undefined for null input', () => {
+      expect(stringify(null, 'test-key')).toBeUndefined();
+    });
+
+    it('should return undefined for Error input', () => {
+      expect(stringify(new Error('test'), 'test-key')).toBeUndefined();
+    });
+  });
+
+  describe('stringifyContentful', () => {
+    it('should stringify valid Contentful entries with metadata', () => {
       const entry = {
         sys: { type: 'Entry', id: 'test' },
         fields: { title: 'Test Entry' }
       };
-
-      const result = stringify(entry, 'test-key');
+      const result = stringifyContentful(entry, 'test-key');
       expect(result).toBeDefined();
-
       const parsed = JSON.parse(result!);
       expect(parsed.sys).toEqual(entry.sys);
       expect(parsed.fields).toEqual(entry.fields);
       expect(parsed.lastrev_metadata).toBeDefined();
     });
 
-    it('should stringify valid Contentful assets', () => {
+    it('should stringify valid Contentful assets with metadata', () => {
       const asset = {
         sys: { type: 'Asset', id: 'test-asset' },
         fields: { file: { url: 'https://example.com/image.jpg' } }
       };
-
-      const result = stringify(asset, 'test-key');
+      const result = stringifyContentful(asset, 'test-key');
       expect(result).toBeDefined();
-
       const parsed = JSON.parse(result!);
       expect(parsed.sys).toEqual(asset.sys);
-      expect(parsed.fields).toEqual(asset.fields);
+      expect(parsed.lastrev_metadata).toBeDefined();
     });
 
     it('should return undefined for null input', () => {
-      const result = stringify(null, 'test-key');
-      expect(result).toBeUndefined();
+      expect(stringifyContentful(null, 'test-key')).toBeUndefined();
     });
 
     it('should return undefined for Error input', () => {
-      const result = stringify(new Error('test'), 'test-key');
-      expect(result).toBeUndefined();
+      expect(stringifyContentful(new Error('test'), 'test-key')).toBeUndefined();
     });
 
     it('should return undefined for Contentful Error objects', () => {
       const contentfulError = { sys: { type: 'Error', id: 'NotFound' } };
-      const result = stringify(contentfulError, 'test-key');
-      expect(result).toBeUndefined();
+      expect(stringifyContentful(contentfulError, 'test-key')).toBeUndefined();
     });
 
     it('should return undefined for non-Contentful objects', () => {
       const invalidObject = { id: 'test', data: 'value' };
-      const result = stringify(invalidObject, 'test-key');
-      expect(result).toBeUndefined();
+      expect(stringifyContentful(invalidObject, 'test-key')).toBeUndefined();
     });
   });
 });

--- a/packages/cms-redis-loader/src/helpers.ts
+++ b/packages/cms-redis-loader/src/helpers.ts
@@ -38,28 +38,30 @@ export const isContentfulError = (item: any) => {
   return item?.sys?.type === 'Error';
 };
 
-export const stringify = (r: any, errorKey: string) => {
+export const stringify = (r: any, errorKey: string): string | undefined => {
   try {
-    if (isNil(r)) {
-      throw Error('nil');
-    }
-
-    if (isError(r)) {
-      throw Error(r.message);
-    }
-
-    if (isContentfulError(r)) {
-      throw Error(`Contentful Error: ${r.sys.id}`);
-    }
-
-    if (!isContentfulObject(r)) {
-      throw Error(`Not contentful Object: ${r}`);
-    }
-
-    return JSON.stringify(enhanceContentfulObjectWithMetadata(r));
+    if (isNil(r)) throw Error('nil');
+    if (isError(r)) throw Error(r.message);
+    return JSON.stringify(r);
   } catch (err: any) {
     logger.error(`Error stringifying ${errorKey}: ${err.message}`, {
       caller: 'stringify',
+      stack: err.stack
+    });
+    return undefined;
+  }
+};
+
+export const stringifyContentful = (r: any, errorKey: string): string | undefined => {
+  try {
+    if (isNil(r)) throw Error('nil');
+    if (isError(r)) throw Error(r.message);
+    if (isContentfulError(r)) throw Error(`Contentful Error: ${r.sys.id}`);
+    if (!isContentfulObject(r)) throw Error(`Not a valid Contentful object: ${r}`);
+    return JSON.stringify(enhanceContentfulObjectWithMetadata(r));
+  } catch (err: any) {
+    logger.error(`Error stringifying ${errorKey}: ${err.message}`, {
+      caller: 'stringifyContentful',
       stack: err.stack
     });
     return undefined;

--- a/packages/cms-redis-loader/src/index.ts
+++ b/packages/cms-redis-loader/src/index.ts
@@ -5,7 +5,7 @@ import { SimpleTimer as Timer } from '@last-rev/timer';
 import Redis from 'ioredis';
 import { ItemKey, CmsLoaders, SanityLoaders, FVLKey, RefByKey } from '@last-rev/types';
 import LastRevAppConfig from '@last-rev/app-config';
-import { getKey, isError, isNil, parse, stringify } from './helpers';
+import { getKey, isError, isNil, parse, stringifyContentful } from './helpers';
 import { primeRedisEntriesByContentType, primeRedisEntriesOrAssets, primeRedisDocumentsByType } from './primers';
 
 const logger = getWinstonLogger({ package: 'cms-redis-loader', module: 'index', strategy: 'Redis' });
@@ -296,7 +296,7 @@ const createContentfulLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsL
     if (cacheMissIds.length) {
       const sourceResults = await fallbackLoader.loadMany(cacheMissIds);
 
-      primeRedisEntriesOrAssets<T>(client, cacheMissIds, dirname, sourceResults, maxBatchSize, ttlSeconds);
+      primeRedisEntriesOrAssets<T>(client, cacheMissIds, dirname, sourceResults, maxBatchSize, ttlSeconds, stringifyContentful);
 
       keys.forEach((key, index) => {
         if (isNil(results[index])) {
@@ -449,7 +449,7 @@ const createContentfulLoaders = (config: LastRevAppConfig, fallbackLoaders: CmsL
           const zipped: Record<string, string> = {};
 
           for (let i = 0; i < contentTypeIds.length; i++) {
-            const val = stringify(contentTypes[i], contentTypeIds[i]);
+            const val = stringifyContentful(contentTypes[i], contentTypeIds[i]);
             if (val) {
               zipped[contentTypeIds[i]] = val;
             }

--- a/packages/cms-redis-loader/src/primers.test.ts
+++ b/packages/cms-redis-loader/src/primers.test.ts
@@ -1,6 +1,7 @@
 import { primeRedisEntriesOrAssets, primeRedisEntriesByContentType } from './primers';
 import RedisMock from 'ioredis-mock';
 import { BaseEntry, ItemKey } from '@last-rev/types';
+import { stringifyContentful } from './helpers';
 
 // Mock dependencies
 jest.mock('@last-rev/logging', () => ({
@@ -43,7 +44,7 @@ describe('primers', () => {
         { sys: { type: 'Entry', id: 'entry2' }, fields: { title: 'Entry 2' } }
       ];
 
-      await primeRedisEntriesOrAssets(mockClient as any, cacheMissIds, 'entries', sourceResults, 1000, 3600);
+      await primeRedisEntriesOrAssets(mockClient as any, cacheMissIds, 'entries', sourceResults, 1000, 3600, stringifyContentful);
 
       // Check that entries were set in Redis
       const entry1 = await mockClient.get('production:entries:entry1');

--- a/packages/cms-redis-loader/src/primers.ts
+++ b/packages/cms-redis-loader/src/primers.ts
@@ -1,7 +1,7 @@
 import Redis from 'ioredis';
 import { SimpleTimer as Timer } from '@last-rev/timer';
 import { BaseEntry, SanityDocument, ItemKey } from '@last-rev/types';
-import { getKey, isNil, isRejected, stringify } from './helpers';
+import { getKey, isNil, isRejected, stringify, stringifyContentful } from './helpers';
 import { getWinstonLogger } from '@last-rev/logging';
 
 const logger = getWinstonLogger({ package: 'cms-redis-loader', module: 'primers' });
@@ -12,7 +12,8 @@ export const primeRedisEntriesOrAssets = async <T>(
   dirname: string,
   sourceResults: (T | Error)[],
   maxBatchSize: number,
-  ttlSeconds: number
+  ttlSeconds: number,
+  serializer: (r: any, errorKey: string) => string | undefined = stringify
 ) => {
   try {
     const timer = new Timer();
@@ -22,8 +23,7 @@ export const primeRedisEntriesOrAssets = async <T>(
 
     for (let i = 0; i < cacheMissIds.length; i++) {
       const key = getKey(cacheMissIds[i], dirname);
-      const value = stringify(sourceResults[i], key);
-      // const value = isNil(sourceResults[i]) ? null : stringify(sourceResults[i], key);
+      const value = serializer(sourceResults[i], key);
       if (key && value) {
         toSet[key] = value;
         if (count++ % maxBatchSize === 0) {
@@ -97,7 +97,7 @@ export const primeRedisEntriesByContentType = async (
       }
 
       entries.forEach((entry) => {
-        const v = isNil(entry) ? null : stringify(entry, entry.sys.id);
+        const v = isNil(entry) ? null : stringifyContentful(entry, entry.sys.id);
         if (v) {
           msetKeys[getKey({ preview, id: entry.sys.id }, 'entries')] = v;
           // chunking to maxBatchSize


### PR DESCRIPTION
## Summary

Refactored the cms-redis-loader to decouple Contentful-specific serialization from generic JSON serialization, enabling support for non-Contentful data sources like Sanity. The `primeRedisEntriesOrAssets` function now accepts an injectable serializer parameter, allowing callers to specify how data should be serialized based on its source.

### Changes
- Split `stringify` into two functions: a generic `stringify` and a Contentful-specific `stringifyContentful`
- Added `serializer` parameter to `primeRedisEntriesOrAssets` with `stringify` as the default
- Updated Contentful loaders to explicitly pass `stringifyContentful` as the serializer
- Updated tests to validate both serialization strategies

### Testing
Existing tests verify both the generic and Contentful-specific serialization paths work correctly. The Contentful loaders continue to use `stringifyContentful` to enhance metadata, while Sanity loaders use the generic `stringify`.