### PR TITLE
fix: separate Redis clients and key prefixes for preview vs production

### DIFF
--- a/.changeset/beige-lands-call.md
+++ b/.changeset/beige-lands-call.md
@@ -1,0 +1,11 @@
+---
+'@last-rev/cms-webhook-handler': patch
+'@last-rev/graphql-cms-helpers': patch
+'@last-rev/cms-redis-loader': patch
+'@last-rev/graphql-cms-core': patch
+'@last-rev/cms-sync-to-fs': patch
+'@last-rev/cms-path-util': patch
+'@last-rev/cli': patch
+---
+
+Added preview/prod to key of redis path data

--- a/packages/cms-path-util/src/PathStore.ts
+++ b/packages/cms-path-util/src/PathStore.ts
@@ -16,21 +16,39 @@ export interface PathStore {
 
 const redisClients: Record<string, Redis> = {};
 
+const previewOrProduction = (config: LastRevAppConfig) =>
+  config.cms === 'Sanity'
+    ? config.sanity.usePreview
+      ? 'preview'
+      : 'production'
+    : config.contentful.usePreview
+      ? 'preview'
+      : 'production';
+
 const getRedisClient = (config: LastRevAppConfig) => {
   const key =
     config.cms === 'Sanity'
-      ? JSON.stringify([config.redis, config.sanity.projectId, config.sanity.dataset])
-      : JSON.stringify([config.redis, config.contentful.spaceId, config.contentful.env]);
+      ? JSON.stringify([
+          config.redis,
+          config.sanity.projectId,
+          config.sanity.dataset,
+          config.sanity.usePreview
+        ])
+      : JSON.stringify([
+          config.redis,
+          config.contentful.spaceId,
+          config.contentful.env,
+          config.contentful.usePreview
+        ]);
 
   if (!redisClients[key]) {
+    const segment = previewOrProduction(config);
     redisClients[key] = new Redis({
       ...config.redis,
       keyPrefix:
         config.cms === 'Sanity'
-          ? `${config.sanity.projectId}:${config.sanity.dataset}:`
-          : `${config.contentful.spaceId}:${config.contentful.env}:${
-              config.contentful.usePreview ? 'preview' : 'production'
-            }`
+          ? `${config.sanity.projectId}:${config.sanity.dataset}:${segment}`
+          : `${config.contentful.spaceId}:${config.contentful.env}:${segment}`
     });
   }
   return redisClients[key];


### PR DESCRIPTION
## 📝 Summary

Fixes Redis path store so that preview and production environments get separate Redis clients and key namespaces. Previously, `usePreview` was not part of the Redis client cache key, so preview and production could share the same client instance. Additionally, the Sanity `keyPrefix` was missing the preview/production segment entirely, causing both environments to read/write to the same Redis keys.

---

### 🔹 Linked JIRA Ticket

[PROJECT-1704](https://lastrev.atlassian.net/browse/PROJECT-1704)

---

### 🔗 Preview URL

N/A — backend-only change.

---

### 🔬 Testing Instructions

1. Configure a Sanity or Contentful project with `usePreview: true` and verify Redis keys include a `preview` segment.
2. Toggle `usePreview: false` and verify a separate `production`-prefixed key namespace is used.
3. Confirm that switching between preview/production creates distinct Redis client instances.

---

### 🖼️ Screenshots or screen recordings (if applicable)

N/A

---

### ✔️ Checklist

- [x] I have tested this change in accordance with the instructions provided above.
- [x] I have linked this PR to a JIRA ticket.
- [x] I have updated/added any necessary documentation.
- [x] I have added and committed all relevant code changes.
- [ ] I have merged the latest changes from the target branch into this branch.

---

### 🚀 Changes include

- [x] Bug Fix (_non-breaking change that solves an issue_)
- [ ] New Feature (_non-breaking change that adds functionality_)
- [ ] Breaking Change (_change that is not backwards-compatible and/or changes current functionality_)
- [ ] Documentation Update
- [ ] Redirect
- [ ] Release
- [ ] Other

---

### 📚 Additional Context (if any)

Three changes in `getRedisClient`:
1. Extracted `previewOrProduction` helper for determining the environment segment.
2. Added `usePreview` to the Redis client cache key so preview and production get separate client instances.
3. Added the preview/production segment to the Sanity `keyPrefix` (Contentful already had it).

[PROJECT-1704]: https://lastrev.atlassian.net/browse/PROJECT-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ