### PR TITLE
fix: match internationalized-array locale on `language` field (sanity-plugin-internationalized-array v5)

### DIFF
--- a/.changeset/sanity-i18n-array-v5-schema.md
+++ b/.changeset/sanity-i18n-array-v5-schema.md
@@ -1,0 +1,9 @@
+---
+'@last-rev/graphql-cms-core': patch
+'@last-rev/cms-path-util': patch
+'@last-rev/types': patch
+---
+
+Update internationalized-array field locale resolution to match `sanity-plugin-internationalized-array` v5's storage shape, where the locale is stored on a `language` field instead of `_key` (`_key` is now a random array-item id, consistent with other Sanity array items). This is a breaking change from the pre-v5 `_key`-as-locale shape.
+
+Also fixes `getDefaultFieldValue` so Sanity i18n array fields are correctly unwrapped to the default-locale value instead of returning the raw array.

--- a/packages/cms-path-util/src/PathUpdater.test.ts
+++ b/packages/cms-path-util/src/PathUpdater.test.ts
@@ -1,0 +1,57 @@
+import { getSlug } from './PathUpdater';
+
+describe('getSlug - Sanity', () => {
+  it('resolves the localized slug from an i18n array by locale', () => {
+    const entry = {
+      slug: [
+        { _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue', value: { current: 'home' } },
+        { _key: 'def456', language: 'es', _type: 'internationalizedArrayStringValue', value: { current: 'inicio' } }
+      ]
+    };
+    expect(getSlug(entry, 'en-US', true)).toBe('home');
+    expect(getSlug(entry, 'es', true)).toBe('inicio');
+  });
+
+  it('returns a plain string value directly (non-slug-object value)', () => {
+    const entry = {
+      slug: [{ _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue', value: 'home' }]
+    };
+    expect(getSlug(entry, 'en-US', true)).toBe('home');
+  });
+
+  it('returns undefined when no entry matches the requested locale', () => {
+    const entry = {
+      slug: [{ _key: 'abc123', language: 'es', _type: 'internationalizedArrayStringValue', value: { current: 'inicio' } }]
+    };
+    expect(getSlug(entry, 'en-US', true)).toBeUndefined();
+  });
+
+  it('returns the raw slug as-is when it is not an i18n array', () => {
+    const entry = { slug: { current: 'home' } };
+    expect(getSlug(entry, 'en-US', true)).toBe('home');
+  });
+
+  it('returns a plain string slug as-is', () => {
+    const entry = { slug: 'home' };
+    expect(getSlug(entry, 'en-US', true)).toBe('home');
+  });
+
+  it('returns undefined when the entry has no slug field', () => {
+    const entry = {};
+    expect(getSlug(entry, 'en-US', true)).toBeUndefined();
+  });
+
+  it('accesses the slug directly when useInternationalizedArrays is false', () => {
+    const entry = {
+      slug: [{ _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue', value: { current: 'home' } }]
+    };
+    expect(getSlug(entry, 'en-US', true, { useInternationalizedArrays: false })).toBeUndefined();
+  });
+});
+
+describe('getSlug - Contentful', () => {
+  it('resolves entry.fields.slug[locale]', () => {
+    const entry = { fields: { slug: { 'en-US': 'home' } } };
+    expect(getSlug(entry, 'en-US', false)).toBe('home');
+  });
+});

--- a/packages/cms-path-util/src/PathUpdater.ts
+++ b/packages/cms-path-util/src/PathUpdater.ts
@@ -52,7 +52,7 @@ const hasSlug = (entry: any, isSanity: boolean): boolean => {
 /**
  * Get slug value from entry for a specific locale
  */
-const getSlug = (
+export const getSlug = (
   entry: any,
   locale: string,
   isSanity: boolean,
@@ -76,8 +76,8 @@ const getSlug = (
       return typeof fieldValue === 'string' ? fieldValue : fieldValue?.current;
     }
 
-    // i18n array format: find by locale key
-    const localized = fieldValue.find((v: any) => v._key === locale);
+    // i18n array format: find by locale
+    const localized = fieldValue.find((v: any) => v.language === locale);
     if (localized?.value !== undefined) {
       return typeof localized.value === 'string' ? localized.value : localized.value?.current;
     }

--- a/packages/graphql-cms-core/src/utils/getDefaultFieldValue.test.ts
+++ b/packages/graphql-cms-core/src/utils/getDefaultFieldValue.test.ts
@@ -1,0 +1,59 @@
+import { ApolloContext, SanityDocument } from '@last-rev/types';
+import getDefaultFieldValue from './getDefaultFieldValue';
+
+const createSanityCtx = (overrides?: Partial<ApolloContext>): ApolloContext =>
+  ({
+    cms: 'Sanity',
+    defaultLocale: 'en-US',
+    sanityConfig: {
+      useInternationalizedArrays: true
+    },
+    ...overrides
+  } as unknown as ApolloContext);
+
+describe('getDefaultFieldValue - Sanity', () => {
+  it('returns the default-locale value from an i18n array', () => {
+    const doc = {
+      title: [
+        { _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Hello' },
+        { _key: 'def456', language: 'es', _type: 'internationalizedArrayStringValue', value: 'Hola' }
+      ]
+    } as unknown as SanityDocument;
+    const ctx = createSanityCtx();
+    expect(getDefaultFieldValue(doc, 'title', ctx)).toBe('Hello');
+  });
+
+  it('returns null when the default locale has no matching entry', () => {
+    const doc = {
+      title: [{ _key: 'def456', language: 'es', _type: 'internationalizedArrayStringValue', value: 'Hola' }]
+    } as unknown as SanityDocument;
+    const ctx = createSanityCtx();
+    expect(getDefaultFieldValue(doc, 'title', ctx)).toBeNull();
+  });
+
+  it('returns the field as-is when useInternationalizedArrays is false', () => {
+    const titleArray = [{ _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Hello' }];
+    const doc = { title: titleArray } as unknown as SanityDocument;
+    const ctx = createSanityCtx({ sanityConfig: { useInternationalizedArrays: false } });
+    expect(getDefaultFieldValue(doc, 'title', ctx)).toEqual(titleArray);
+  });
+
+  it('returns non-array field values as-is', () => {
+    const doc = { title: 'Direct string' } as unknown as SanityDocument;
+    const ctx = createSanityCtx();
+    expect(getDefaultFieldValue(doc, 'title', ctx)).toBe('Direct string');
+  });
+});
+
+describe('getDefaultFieldValue - Contentful', () => {
+  it('reads item.fields[fieldName][defaultLocale] when a default locale string is passed', () => {
+    const item = { fields: { title: { 'en-US': 'Hello' } } };
+    expect(getDefaultFieldValue(item as any, 'title', 'en-US')).toBe('Hello');
+  });
+
+  it('reads item.fields[fieldName][ctx.defaultLocale] when an ApolloContext is passed', () => {
+    const item = { fields: { title: { 'en-US': 'Hello' } } };
+    const ctx = { cms: 'Contentful', defaultLocale: 'en-US' } as unknown as ApolloContext;
+    expect(getDefaultFieldValue(item as any, 'title', ctx)).toBe('Hello');
+  });
+});

--- a/packages/graphql-cms-core/src/utils/getDefaultFieldValue.ts
+++ b/packages/graphql-cms-core/src/utils/getDefaultFieldValue.ts
@@ -25,7 +25,8 @@ const getDefaultFieldValue = (
     // Sanity fields are directly on the document
     const val = (item as SanityDocument)[fieldName];
     if (ctx.sanityConfig?.useInternationalizedArrays && Array.isArray(val) && val[0]?._key) {
-      return val;
+      const defaultLocalized = val.find((v: any) => v.language === ctx.defaultLocale);
+      return defaultLocalized?.value ?? null;
     }
     return val;
   }

--- a/packages/graphql-cms-core/src/utils/getLocalizedField.test.ts
+++ b/packages/graphql-cms-core/src/utils/getLocalizedField.test.ts
@@ -19,8 +19,8 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
   it('returns localized value when value property is present', () => {
     const doc = asDoc({
       title: [
-        { _key: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Hello' },
-        { _key: 'es', _type: 'internationalizedArrayStringValue', value: 'Hola' }
+        { _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Hello' },
+        { _key: 'def456', language: 'es', _type: 'internationalizedArrayStringValue', value: 'Hola' }
       ]
     });
     const ctx = createSanityCtx();
@@ -30,8 +30,8 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
   it('returns localized value for non-default locale', () => {
     const doc = asDoc({
       title: [
-        { _key: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Hello' },
-        { _key: 'es', _type: 'internationalizedArrayStringValue', value: 'Hola' }
+        { _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Hello' },
+        { _key: 'def456', language: 'es', _type: 'internationalizedArrayStringValue', value: 'Hola' }
       ]
     });
     const ctx = createSanityCtx({ locale: 'es' });
@@ -40,7 +40,7 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
 
   it('returns null when i18n array entry has no value property (only _key and _type)', () => {
     const doc = asDoc({
-      title: [{ _key: 'en-US', _type: 'internationalizedArrayStringValue' }]
+      title: [{ _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayStringValue' }]
     });
     const ctx = createSanityCtx();
     expect(getLocalizedField(doc, 'title', ctx)).toBeNull();
@@ -48,7 +48,7 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
 
   it('returns null when i18n array has entries for other locales but not the requested one', () => {
     const doc = asDoc({
-      title: [{ _key: 'es', _type: 'internationalizedArrayStringValue' }]
+      title: [{ _key: 'abc123', language: 'es', _type: 'internationalizedArrayStringValue' }]
     });
     const ctx = createSanityCtx({ locale: 'en-US' });
     expect(getLocalizedField(doc, 'title', ctx)).toBeNull();
@@ -56,7 +56,7 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
 
   it('returns null for internationalizedArrayReferenceValue with no value', () => {
     const doc = asDoc({
-      image: [{ _key: 'en-US', _type: 'internationalizedArrayReferenceValue' }]
+      image: [{ _key: 'abc123', language: 'en-US', _type: 'internationalizedArrayReferenceValue' }]
     });
     const ctx = createSanityCtx();
     expect(getLocalizedField(doc, 'image', ctx)).toBeNull();
@@ -65,8 +65,8 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
   it('returns null when fallback is disabled and requested locale has no value but default does', () => {
     const doc = asDoc({
       title: [
-        { _key: 'es', _type: 'internationalizedArrayStringValue' },
-        { _key: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Default value' }
+        { _key: 'abc123', language: 'es', _type: 'internationalizedArrayStringValue' },
+        { _key: 'def456', language: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Default value' }
       ]
     });
     const ctx = createSanityCtx({ locale: 'es' });
@@ -76,8 +76,8 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
   it('falls back to default locale when configured and primary locale has no value', () => {
     const doc = asDoc({
       title: [
-        { _key: 'es', _type: 'internationalizedArrayStringValue' },
-        { _key: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Fallback' }
+        { _key: 'abc123', language: 'es', _type: 'internationalizedArrayStringValue' },
+        { _key: 'def456', language: 'en-US', _type: 'internationalizedArrayStringValue', value: 'Fallback' }
       ]
     });
     const ctx = createSanityCtx({
@@ -93,8 +93,8 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
   it('returns null when fallback is enabled but both locales have no value', () => {
     const doc = asDoc({
       title: [
-        { _key: 'es', _type: 'internationalizedArrayStringValue' },
-        { _key: 'en-US', _type: 'internationalizedArrayStringValue' }
+        { _key: 'abc123', language: 'es', _type: 'internationalizedArrayStringValue' },
+        { _key: 'def456', language: 'en-US', _type: 'internationalizedArrayStringValue' }
       ]
     });
     const ctx = createSanityCtx({
@@ -109,8 +109,8 @@ describe('getLocalizedField - Sanity i18n arrays', () => {
 
   it('returns array as-is when items have _key and value but non-i18n _type', () => {
     const options = [
-      { _key: 'en-US', _type: 'option', value: 'Option A' },
-      { _key: 'es', _type: 'option', value: 'Option B' }
+      { _key: 'abc123', language: 'en-US', _type: 'option', value: 'Option A' },
+      { _key: 'def456', language: 'es', _type: 'option', value: 'Option B' }
     ];
     const doc = asDoc({ options });
     const ctx = createSanityCtx();

--- a/packages/graphql-cms-core/src/utils/getLocalizedField.ts
+++ b/packages/graphql-cms-core/src/utils/getLocalizedField.ts
@@ -23,7 +23,7 @@ const getLocalizedField = (entry: CmsEntry, field: string, ctx: ApolloContext): 
  *
  * Config options (from ctx.sanityConfig):
  * - useInternationalizedArrays (default: true)
- *   - true: Fields use [{ _key: 'en', value: ... }] format
+ *   - true: Fields use [{ _key: 'abc123', language: 'en', value: ... }] format
  *   - false: Fields accessed directly (doc.field)
  *
  * - fallbackToDefaultLocale (default: false)
@@ -45,21 +45,21 @@ const getSanityField = (doc: any, field: string, ctx: ApolloContext): any => {
   }
 
   // Check if this is an i18n array format
-  // i18n arrays are identified by _type matching internationalizedArray*Value (from @sanity/document-internationalization)
+  // i18n arrays are identified by _type matching internationalizedArray*Value (from sanity-plugin-internationalized-array)
   // Regular Sanity arrays have _key (random ID) but a non-i18n _type
   if (!Array.isArray(fieldValue) || !fieldValue[0]?._key || !isI18nArrayType(fieldValue[0]?._type)) {
     // Not an i18n array - return as-is (supports regular arrays, references, etc.)
     return fieldValue;
   }
 
-  // i18n array format: find by locale key
+  // i18n array format: find by locale
   const locale = ctx.locale ?? ctx.defaultLocale;
-  const localized = fieldValue.find((v: any) => v._key === locale);
+  const localized = fieldValue.find((v: any) => v.language === locale);
   if (localized?.value !== undefined) return localized.value;
 
   // Only fallback to default locale if configured
   if (fallbackToDefault && locale !== ctx.defaultLocale) {
-    const defaultLocalized = fieldValue.find((v: any) => v._key === ctx.defaultLocale);
+    const defaultLocalized = fieldValue.find((v: any) => v.language === ctx.defaultLocale);
     if (defaultLocalized?.value !== undefined) return defaultLocalized.value;
   }
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -41,8 +41,10 @@ export type SanitySlug = Slug;
  * }
  */
 export interface InternationalizedValue<T> {
-  /** Locale code (e.g., 'en-US', 'es-ES') */
+  /** Random array-item id (Sanity's standard `_key`, not the locale) */
   _key: string;
+  /** Locale code (e.g., 'en-US', 'es-ES') */
+  language: string;
   /** The localized value */
   value: T;
 }


### PR DESCRIPTION
## Summary
- `sanity-plugin-internationalized-array` v5 moved the locale off `_key` (now a random id) onto a new `language` field, breaking our locale resolution which assumed `_key === locale`.
- Since all consumers are still in active development, this is a clean cutover (no old-shape fallback) rather than dual-shape detection.
- Updates `getLocalizedField`/`getSanityField` and `getDefaultFieldValue` in `@last-rev/graphql-cms-core`, `getSlug` in `@last-rev/cms-path-util` (now exported for testability), and the `InternationalizedValue<T>` type in `@last-rev/types`.
- Also fixes a pre-existing bug in `getDefaultFieldValue` where the i18n-array branch never actually unwrapped to the default-locale value.
- Adds a changeset for the three affected packages.

## Test plan
- [x] `pnpm --filter @last-rev/graphql-cms-core test` — 91 tests passing
- [x] `pnpm --filter @last-rev/cms-path-util test` — 88 tests passing (including new `PathUpdater.test.ts`)
- [x] `pnpm build` — all 27 workspace packages build cleanly